### PR TITLE
feat: new ComfyUI Cloud models — multi-ref image gen + start/end keyframe video

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,10 @@ env/
 # Temporary files
 tmp/
 
+# Local model weights (e.g. InsightFace inswapper_128.onnx, buffalo_l) — large,
+# gated/licensed; mounted into the backend container, never committed.
+models/
+
 # Credentials
 *.json
 !config.json

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,8 +3,8 @@ gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
 status: Awaiting next milestone
-stopped_at: Completed 26-03-PLAN.md
-last_updated: "2026-06-08T02:30:52.923Z"
+stopped_at: context exhaustion at 75% (2026-06-14)
+last_updated: "2026-06-14T01:19:42.754Z"
 last_activity: 2026-06-08
 progress:
   total_phases: 28
@@ -378,8 +378,8 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-03-14T23:25:06.412Z
-Stopped at: Completed 26-03-PLAN.md
+Last session: 2026-06-14T01:19:42.747Z
+Stopped at: context exhaustion at 75% (2026-06-14)
 Resume file: None
 
 ## Deferred Items

--- a/.planning/decisions/2026-06-11-comfyui-new-models.md
+++ b/.planning/decisions/2026-06-11-comfyui-new-models.md
@@ -1,0 +1,117 @@
+# ADR: New ComfyUI Cloud models — multi-ref image generation and FLF2V video
+
+**Date:** 2026-06-11
+**Status:** Accepted
+
+## Context
+
+The ComfyUI integration previously offered txt2img-only Qwen, single-image
+qwen-image-edit, style-only Flux Redux references, and start-frame-only WAN
+2.2 video. Production-bible identity references (the Nano Banana machinery)
+were gated to Gemini models, and the end keyframe was loaded but never used
+on the ComfyUI video path.
+
+This phase adds:
+
+| Model ID | Capability |
+|---|---|
+| `qwen-image-edit-2509` | 1–3 identity reference images (Apache 2.0) |
+| `flux-2-klein` | 0–4 reference images, plain txt2img at 0 (Apache 2.0, 4B distilled) |
+| `wan-2.2-flf2v` | Start+end keyframe interpolation, same weights as wan-2.2-i2v |
+| `ltx-2.3-flf2v` | Start+end keyframes @25fps, 4–10s, native audio (open weights) |
+| `seedance-2.0-flf2v` | Start+(optional)end, 4–15s, audio — paid ByteDance partner node |
+
+## Decisions
+
+### 1. Committed API-format templates, no runtime conversion
+
+Official Comfy-Org templates use the subgraph app format, which
+`_convert_app_to_api` cannot handle (and whose `_WIDGET_NAMES` positional
+mapping silently mis-maps unknown node classes). We hand-assembled minimal
+flat API-format graphs (`backend/vidpipe/services/comfyui_templates/`) from
+the official subgraph internals, with raw app-format copies archived under
+`docs/comfyui-templates/`. Node input names were verified against ComfyUI
+source (`comfy_extras/*`, `comfy_api_nodes/nodes_bytedance.py`).
+
+### 2. Qwen 2509 refs-as-inputs mapping
+
+Qwen-Image-Edit is an edit model: the input images ARE the references.
+Mapping onto our two keyframe modes:
+
+- **End-frame mode:** `image1` = start frame (drives output dimensions and
+  visual conditioning via ReferenceLatent), `image2/3` = identity refs.
+  This gives ComfyUI models true start-frame-conditioned end keyframes for
+  the first time.
+- **Start-frame mode:** the template KSampler runs at denoise 1.0, so the
+  `latent_image` input only determines output dimensions. We patch in an
+  `EmptySD3LatentImage` at the scene aspect ratio and use all 3 slots for
+  identity refs. With zero refs the model cannot run — we fall back to
+  qwen-fast txt2img (logged).
+- **Ref-slot reservation:** identity-ref selection is capped at 2 for qwen
+  (3rd slot reserved for the start frame in end-frame mode) and 3 for klein
+  (1 of 4 reserved).
+
+### 3. ComfyUI models now use the Nano Banana reference machinery
+
+`COMFYUI_MULTIREF_IMAGE_MODELS` widens the gate at keyframes.py so
+face/wardrobe candidate selection, identity-policy face cropping, emphasis
+escalation, and post-generation face verification all apply to
+qwen-image-edit-2509 and flux-2-klein. **Consequence:** identity
+verification (and its retries) is newly active for ComfyUI image models on
+production-bible scenes — intentional, watch generation latency.
+
+### 4. Video adapter spec registry
+
+`COMFY_VIDEO_SPECS` in `comfyui_adapter.py` holds per-model behavior: fps,
+fixed-vs-requested duration, end-frame/audio/char-ref support, and the
+framing-safety prompt prefix (moved out of video_gen.py). `submit()` gained
+`duration_seconds`/`audio_enabled`; `download()` gained
+`video_model`/`duration_seconds` with WAN-compatible defaults so in-flight
+`comfyui:{prompt_id}` operations survive a deploy. The operation-ID format
+is unchanged. `COMFYUI_VIDEO_MODELS` (video_gen.py) and `COMFY_VIDEO_SPECS`
+must stay in sync (pinned by a unit test).
+
+### 5. FLF2V soft degrade
+
+A missing end keyframe on an FLF2V model logs a warning and degrades to
+first-frame-only generation (wan-flf2v → i2v workflow; ltx → single guide;
+seedance → omit last_frame) instead of failing the shot. Rationale:
+uploaded/gap-filled shots can legitimately lack an end keyframe.
+
+### 6. Seedance pricing and auth
+
+Cost set to $0.22/s (silent and audio) from the partner node's own pricing
+expression: 21,600 tokens/s @720p × ~$0.01001/1K tokens, audio included.
+**Known caveat:** partner API nodes authenticate via a logged-in Comfy Org
+account, not the plain `X-API-Key` our client sends — the live smoke test
+failed with "Unauthorized: Please login first to use this node" after the
+workflow itself validated. Account-level setup (Comfy login / credit
+balance / API-key partner-node permission) is required before
+seedance-2.0-flf2v works end-to-end. The error surfaces cleanly in
+`clip.error_message`.
+
+### 7. Frontend provider field
+
+Model options now carry `provider: "vertex" | "comfyui"`; the Settings-page
+groupings filter on it instead of `id.startsWith(...)` (which would have
+orphaned `ltx-*`/`seedance-*` from every group).
+
+## Verification
+
+- 34 unit tests (builders, adapter dispatch, catalog consistency) green;
+  full backend suite 84 passed with only two pre-existing failures.
+- Live Comfy Cloud smoke tests (backend/tests/comfyui/test_new_models.py):
+  - qwen-2509: SUCCESS — 1664×928 output at requested scene dims
+  - flux2-klein: SUCCESS — single-ref generation in ~10s
+  - ltx: SUCCESS — 1280×704 @25fps h264 with non-silent AAC audio
+    (VAE rounds 720→704; consistent across clips)
+  - seedance: workflow accepted, blocked on partner-node account auth (see §6)
+
+## Consequences
+
+- LTX outputs are 25fps/704p-class vs WAN's 16fps/480p-class — mixed-model
+  scenes rely on the ffmpeg stitcher normalizing (same as Veo 24fps today).
+- Seedance is the first ComfyUI model with a real per-second cost; UI cost
+  estimates now reflect it.
+- The five flux-dev legacy models remain unchanged for backward
+  compatibility.

--- a/.planning/decisions/2026-06-12-clip-validation-and-orphan-recovery.md
+++ b/.planning/decisions/2026-06-12-clip-validation-and-orphan-recovery.md
@@ -1,0 +1,84 @@
+# ADR: Degenerate-clip validation gate and restart-orphan recovery
+
+**Date:** 2026-06-12
+**Status:** Accepted
+
+## Context
+
+Two production failures surfaced after the new ComfyUI FLF2V models shipped:
+
+1. **Corrupted clip stitched into a finished production** (production
+   `37375853`, scene `2589fc91`, shot 1). The `wan-2.2-flf2v` job reported
+   `success` on ComfyUI Cloud and its server-side QC PNG frames were clean,
+   but the MP4 that `SaveVideo` encoded contained a static noise pattern for
+   every frame between the two pinned conditioning frames. The downloaded
+   bytes were byte-identical to the server's file — this is provider-side
+   encode corruption we cannot prevent, only detect. The pipeline had no
+   quality gate on the ComfyUI download path, so the garbage clip was marked
+   `complete`, stitched into the scene, and rendered into the production
+   master.
+
+2. **Productions stranded mid-run by container rebuilds.** Pipelines run as
+   in-process asyncio tasks; rebuilding the backend container kills them.
+   Scenes were left in `generating_video` with clips stuck in `polling`
+   forever (the underlying ComfyUI job had actually succeeded).
+   `generating_video` — a transient status set by `generate_keyframes` and
+   normally renamed by the orchestrator moments later — was neither in
+   `RESUMABLE_STATES` nor in the stop endpoint's `ACTIVE_STATUSES`, so the
+   stranded scenes could not be resumed *or* stopped. Three E2E productions
+   on 2026-06-11 died this way.
+
+## Decisions
+
+### 1. Frequency-spectrum noise gate on downloaded clips (`services/clip_validation.py`)
+
+Every ComfyUI clip download (main pipeline and `_regenerate_clip`) is checked
+before being accepted:
+
+- **Noise signature** — ratio of mid-frequency band energy (between 1/4 and
+  1/16 scale) to low-frequency structure, per sampled frame. Natural frames
+  follow a ~1/f spectrum (measured ≤ 0.30 on real clips, including a
+  near-black lens-occlusion frame); the observed corruption scores ≥ 3.8.
+- **Keyframe anchors** — first frame must correlate with the start keyframe;
+  last frame with the end keyframe when FLF2V conditioning was used
+  (Pearson on downscaled grayscale; catches wrong-video downloads).
+- **Temporal continuity is diagnostic only.** A hard continuity gate was
+  prototyped and rejected: a *good* LTX clip contained a legitimate
+  near-discontinuity (object sweeping across the lens) that would have been
+  a false positive.
+
+On failure the shot is resubmitted with a **perturbed seed**
+(`seed + attempt * 1000003`) — same seed would risk ComfyUI's node cache
+serving the identical corrupted encode — up to
+`pipeline.clip_corrupt_retry_max` (default 2) times, then the scene fails
+loudly with the validation detail in `error_message`.
+
+Config: `pipeline.clip_validation_enabled` (default true).
+
+### 2. Startup auto-resume of orphaned scenes (`orchestrator/recovery.py`)
+
+On startup the API spawns a background task that finds scenes in in-flight
+statuses (`pending`, `storyboarding`, `keyframing`, `generating_video`,
+`video_gen`, `stitching`) and re-runs `run_pipeline` for each, sequentially.
+Every stage checkpoints to the DB, so resume is idempotent: completed stages
+are skipped and in-flight ComfyUI jobs are re-polled via the persisted
+`comfyui:` operation id. Config: `pipeline.auto_resume_on_startup`
+(default true — interrupted runs were already paid for and user-requested).
+
+`generating_video` was added to `RESUMABLE_STATES`/`ACTIVE_STATUSES`, maps to
+`video_gen` in `get_resume_step`, and `run_pipeline` normalizes it at entry
+(previously a scene entering in that status matched no step block and
+no-opped straight to "completed successfully").
+
+## Consequences
+
+- Corrupted provider output can no longer silently reach a stitched scene;
+  worst case is a clearly-reported scene failure after N retries.
+- Container rebuilds mid-run self-heal on next startup instead of stranding
+  productions.
+- Validation thresholds were calibrated against the real corrupted clip and
+  seven real good clips (WAN + LTX); unit tests pin the behavior with
+  synthetic fixtures (`tests/test_clip_validation.py`,
+  `tests/test_orphan_recovery.py`).
+- Veo path is unchanged (no corruption observed there; it has its own
+  quality-mode scoring).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
 - `cd frontend && npm run lint`: run ESLint.
 - `pytest backend/` and `ruff check backend/`: run backend tests and lint.
 - `docker compose up -d --build backend frontend`: rebuild production containers after code changes. `docker-compose.dev.yml` auto-reloads code, but dependency changes still require rebuilds.
+- `./scripts/start-stack.sh [--build]`: bring up the full stack (external Supabase + app) safely. Use this instead of starting services by hand — it applies the S3 overlay and auto-repairs the WSL2 bind-mount failure modes noted below.
 
 ## Coding Style & Naming Conventions
 Python uses 4-space indentation, snake_case names, type hints on all signatures, and async-first I/O with `async def` and `await`. Follow existing service and route boundaries, and use migrations or column adds for schema changes rather than recreating the database. TypeScript uses strict mode: PascalCase for components, camelCase for helpers, and `import type` for type-only imports. Keep frontend files focused and match existing hook patterns.
@@ -21,3 +22,6 @@ Name backend tests `test_<feature>.py` and focus coverage on pipeline logic, API
 
 ## Commit, PR, and Environment Rules
 Use conventional commits such as `feat:`, `fix:`, and `docs:`. This repo uses git worktrees, so only edit files in the current worktree and never delete or recreate `vidpipe.db` without approval. Read `.env` for `VIDPIPE_SERVER__PORT`, `VIDPIPE_STORAGE__DATABASE_URL`, and temp/output paths instead of hardcoding defaults. PRs should include the problem, verification steps, linked issues, config or migration impact, and screenshots for UI changes. Add an ADR under `.planning/decisions/` for non-trivial architectural or schema decisions, and never commit `.env`, service-account JSON, or generated media.
+
+## Runtime Dependency: Supabase (Docker, WSL2)
+Production depends on an external self-hosted Supabase stack (sibling dir, e.g. `../supabase-project/`) for PostgreSQL and MinIO-backed object storage; never `down -v` it. Always run it with **both** compose files (`-f docker-compose.yml -f docker-compose.s3.yml`) for `up` and `down` — the base file alone uses the file storage backend (media GETs 500 with `EISDIR`) and omits MinIO. On Docker Desktop + WSL2, a host/Docker restart can leave a stale bind-mount cache: containers `Exit(127)` with `not a directory` (fix by recreating — `down` then `up`, not `restart`), and MinIO can format an empty pool and serve a blank bucket (fix with `up -d --force-recreate --no-deps minio`; on-disk objects are not lost). `./scripts/start-stack.sh` handles all of this; see the README Troubleshooting section for details.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,9 @@ Routing via wouter. State via React hooks (no Redux). Vite dev server proxies `/
 
 ## ComfyUI Routing (CRITICAL)
 
-`COMFYUI_VIDEO_MODELS` in `video_gen.py` is the router (`wan-2.2-i2v`). **Both the main pipeline AND `_regenerate_clip` in `routes.py` must check this set.** Missing the check in either place causes silent routing failures — clips will be sent to Veo instead of ComfyUI (or vice versa) with no error, just wrong output. ComfyUI is actively used in production.
+`COMFYUI_VIDEO_MODELS` in `video_gen.py` is the router (`wan-2.2-i2v`, `wan-2.2-flf2v`, `ltx-2.3-flf2v`, `seedance-2.0-flf2v`). **Both the main pipeline AND `_regenerate_clip` in `routes.py` must check this set.** Missing the check in either place causes silent routing failures — clips will be sent to Veo instead of ComfyUI (or vice versa) with no error, just wrong output. ComfyUI is actively used in production.
+
+Per-model ComfyUI behavior (fps, end-frame/audio support, workflow builder) lives in `COMFY_VIDEO_SPECS` in `services/comfyui_adapter.py` — it must stay in sync with `COMFYUI_VIDEO_MODELS` (a unit test pins this). FLF2V models degrade to first-frame-only generation when the end keyframe is missing. Audio on the ComfyUI path: `ltx-2.3-flf2v` and `seedance-2.0-flf2v` support `generate_audio`; WAN models do not. Seedance is a paid ByteDance partner node and requires Comfy Org account auth beyond the API key.
 
 ## Database (Per Worktree)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,15 @@ The app runs in Docker containers. **Code changes are not live until containers 
 - **`docker-compose.yml`** — Production: static frontend build (nginx), PostgreSQL via Supabase pooler (port 6543), S3 storage
 - **`docker-compose.dev.yml`** — Development: Vite dev server with HMR, backend `--reload`, SQLite, volume-mounted source code (changes auto-reload)
 
+### Supabase Dependency & Safe Startup (CRITICAL)
+
+The production stack depends on an **external self-hosted Supabase** project (sibling dir, e.g. `../supabase-project/`) for PostgreSQL and object storage. Prefer **`./scripts/start-stack.sh`** to bring everything up — it starts Supabase + app in order and auto-repairs the WSL2 failure modes below. Do not `docker compose down -v` the Supabase stack.
+
+- **Always run Supabase with BOTH compose files:** `docker compose -f docker-compose.yml -f docker-compose.s3.yml ...` (for `up` and `down`). The base file sets storage `STORAGE_BACKEND=file` and omits the `minio` service; the `docker-compose.s3.yml` overlay switches storage to `s3 → http://minio:9000`. Objects live in **MinIO**; the backend reaches it via `S3_ENDPOINT=http://supabase-kong:8000/storage/v1`. Bringing the stack up with the base file alone makes all media GETs fail with `EISDIR`/500.
+- **Recreate, don't restart, on stale-mount crashes:** after a Docker Desktop / WSL restart, containers may `Exit(127)` with `OCI runtime create failed ... not a directory` — a stale Docker Desktop WSL bind-mount cache, not a config error. `docker restart` reuses the broken spec and loops; `down` + `up` (with both files) re-resolves the mounts.
+- **MinIO can format an empty pool:** MinIO (`/data`) and `supabase-storage` (`/var/lib/storage`) bind-mount the *same* host dir. If MinIO's cached view goes empty after a restart it logs `Formatting 1st pool` and serves a blank bucket (media 400s). The objects are NOT lost — recover with `docker compose -f ... -f docker-compose.s3.yml up -d --force-recreate --no-deps minio`. Confirm with `du -sh /data` inside the minio container vs `/var/lib/storage` inside storage.
+- `supabase-storage` reporting `(unhealthy)` is cosmetic (healthcheck probes IPv6 `localhost`; service is on IPv4). It still serves.
+
 ### Rebuilding After Code Changes (CRITICAL)
 
 **Production mode (`docker-compose.yml`):** Source code is COPIED into images at build time. After modifying backend Python or frontend TypeScript/React code, you **must rebuild** for changes to take effect:

--- a/README.md
+++ b/README.md
@@ -197,6 +197,41 @@ uvicorn vidpipe.api.app:app --host 0.0.0.0 --port 8000
 
 Requires Python 3.11+, Node.js 18+, and ffmpeg (`apt-get install ffmpeg` / `brew install ffmpeg`). See [backend/README.md](backend/README.md) and [frontend/README.md](frontend/README.md) for development details, tests, and CLI usage.
 
+## Testing
+
+The suite is offline and fast by default — the paid cloud E2E tests skip unless explicitly enabled:
+
+```bash
+pytest backend/          # full suite (cloud E2E tests skip without their flags)
+ruff check backend/      # lint
+```
+
+### End-to-end test (opt-in, paid cloud)
+
+`backend/tests/test_cyberpunk_seedance_e2e.py` builds a **complete narrated short** against a running stack — bible, cast (lead + a voice-only narrator), sets/props, screenplay, scenes (storyboard → keyframes → video), narration, sound deck, and a rendered master — then asserts the master has real (non-silent) audio. It spends real provider credits, so it's gated behind an env flag and skipped by default.
+
+**Prerequisites** (checked by the test's preflight):
+
+- The app stack running, backend reachable at `http://localhost:8100`
+- **ComfyUI** host + API key and an **ElevenLabs** key + a **default voice**, set in the Settings UI
+- The asset-library actor **"Brandon"** present (reused as the lead)
+
+**Run it:**
+
+```bash
+# The test defaults to seedance-2.0-flf2v, a gated ByteDance partner node. Unless
+# your ComfyUI Cloud account has partner-node (API node) access, override to LTX —
+# otherwise every video job fails with "Unauthorized: Please login first…".
+VIDPIPE_RUN_CYBERPUNK_E2E=1 \
+VIDPIPE_CYBERPUNK_E2E_VIDEO_MODEL=ltx-2.3-flf2v \
+pytest backend/tests/test_cyberpunk_seedance_e2e.py -q -s
+```
+
+It prints `PRODUCTION_ID=…` on success; view the result at
+`http://localhost/api/productions/<id>/master-video`.
+
+**Useful overrides** (all optional): `VIDPIPE_E2E_API_BASE` (`http://localhost:8100`), `VIDPIPE_CYBERPUNK_E2E_IMAGE_MODEL` (`flux-2-klein`), `VIDPIPE_CYBERPUNK_E2E_SCENE_COUNT` (`3`), `VIDPIPE_CYBERPUNK_E2E_SHOTS_PER_SCENE` (`2`), `VIDPIPE_CYBERPUNK_E2E_CLIP_DURATION` (`10`), `VIDPIPE_CYBERPUNK_E2E_TEXT_MODEL` (`gemini-3.5-flash`). A sibling `test_nasa_documentary_e2e.py` follows the same shape with a documentary screenplay.
+
 ## Supported models
 
 All models are selectable per scene in the UI.

--- a/README.md
+++ b/README.md
@@ -87,21 +87,33 @@ The app runs as two containers (FastAPI backend + nginx-served React frontend) a
 - **ElevenLabs API key** (optional) — needed for narration TTS and SFX generation
 - **ComfyUI** (optional) — needed only for WAN video models (`wan-2.2-i2v`)
 
+### Recommended: one-command safe start
+
+`scripts/start-stack.sh` brings up Supabase **and** the app in the right order, with the S3 overlay, and automatically detects and repairs the two Docker Desktop + WSL2 failure modes described in [Troubleshooting](#troubleshooting) (stale bind mounts and MinIO formatting an empty pool):
+
+```bash
+./scripts/start-stack.sh          # bring everything up safely (idempotent)
+./scripts/start-stack.sh --build  # also rebuild the app images
+# SUPABASE_DIR=/path/to/supabase-project ./scripts/start-stack.sh   # non-sibling layout
+```
+
+It never passes `down -v`, so your database and object storage are never wiped. The manual steps below are what the script automates.
+
 ### 2. Start Supabase with the S3 overlay
 
-Supabase Storage **must** run with the S3 compose overlay so it talks to MinIO over HTTP. Without it, storage defaults to `STORAGE_BACKEND=file` and every asset request fails with a 500 (`EISDIR`):
+Supabase Storage **must** run with the S3 compose overlay so it talks to MinIO over HTTP. Without it, storage defaults to `STORAGE_BACKEND=file` and every asset request fails with a 500 (`EISDIR`), because MinIO stores objects in a directory-based format the file backend can't read:
 
 ```bash
 cd ../supabase-project
 
-# Correct — includes the S3 overlay
+# Correct — includes the S3 overlay (always pass BOTH files)
 docker compose -f docker-compose.yml -f docker-compose.s3.yml up -d
 
 # WRONG — storage defaults to file backend, all asset GETs return 500
 # docker compose up -d
 ```
 
-Remember the overlay every time you restart Supabase. Verify with:
+Always pass **both** compose files for every `up` **and** `down`. The base file alone also omits the `minio` service entirely, so MinIO never gets refreshed. Verify with:
 
 ```bash
 docker exec supabase-storage env | grep STORAGE_BACKEND
@@ -198,15 +210,41 @@ Native clip audio is supported on Veo 3+, LTX 2.3, and Seedance 2.0; WAN clips a
 
 ## Troubleshooting
 
-**All images/assets return 500; backend logs show `FileNotFoundError: S3 GET failed: 500`.**
-Supabase Storage is running with the file backend instead of S3. Restart it with the overlay:
+> The fastest fix for all three issues below is to re-run `./scripts/start-stack.sh`, which detects and repairs them automatically.
+
+**All images/assets return 500; backend logs show `FileNotFoundError: S3 GET failed: 500` (`EISDIR`).**
+Supabase Storage is running with the file backend instead of S3, so it tries to read MinIO's directory-format objects as plain files. Bring it back up with the overlay:
 
 ```bash
 cd ../supabase-project
 docker compose -f docker-compose.yml -f docker-compose.s3.yml up -d storage
 ```
 
-`docker compose down` preserves volumes and bind-mounted data (MinIO `./volumes/storage/`, PostgreSQL `./volumes/db/data/`) — just remember the S3 overlay when bringing services back up.
+**Supabase containers crash-loop with `Exited (127)` after a Docker Desktop / WSL restart.**
+`docker inspect` shows `OCI runtime create failed ... not a directory: Are you trying to mount a directory onto a file?`. This is a **stale Docker Desktop WSL2 bind-mount cache** (under `/run/desktop/mnt/host/wsl/docker-desktop-bind-mounts/`), not a bad config — the host source files are fine. A plain `docker restart` reuses the broken mount spec and keeps looping. **Recreate** instead so Docker re-resolves the mounts:
+
+```bash
+cd ../supabase-project
+docker compose -f docker-compose.yml -f docker-compose.s3.yml down   # never -v
+docker compose -f docker-compose.yml -f docker-compose.s3.yml up -d
+cd ../video-pipeline && docker compose restart backend               # reconnect to the DB
+```
+
+**Assets return 400 and MinIO logs show `Formatting 1st pool`.**
+MinIO and `supabase-storage` bind-mount the **same** host dir (`./volumes/storage`). After a restart, the WSL bind-mount cache can give MinIO an empty view of that dir, so it declares the drive unreadable and formats a fresh, empty pool. **Your objects are not lost** — they're still on the host (visible to `supabase-storage`, which mounts the same dir). Force-recreate just MinIO so its `/data` mount re-resolves to the real objects:
+
+```bash
+cd ../supabase-project
+docker compose -f docker-compose.yml -f docker-compose.s3.yml up -d --force-recreate --no-deps minio
+# verify it sees the real data again:
+docker exec "$(docker compose -f docker-compose.yml -f docker-compose.s3.yml ps -q minio)" du -sh /data
+```
+
+If MinIO still sees an empty `/data` after recreating, fully restart Docker Desktop to rebuild its bind-mount cache — the on-disk objects under `./volumes/storage` remain intact.
+
+**`supabase-storage` shows `(unhealthy)` but assets load fine.** Cosmetic: its healthcheck probes `localhost:5000` (resolves to IPv6 `[::1]`, refused) while the server listens on IPv4. Real traffic via `storage:5000` works; nothing depends on its health status.
+
+`docker compose down` (without `-v`) preserves volumes and bind-mounted data (MinIO `./volumes/storage/`, PostgreSQL `./volumes/db/data/`) — just remember to pass **both** compose files when bringing services back up.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -190,11 +190,11 @@ Requires Python 3.11+, Node.js 18+, and ffmpeg (`apt-get install ffmpeg` / `brew
 All models are selectable per scene in the UI.
 
 - **Text (screenplay/storyboard):** Gemini 2.5 Flash / Flash Lite / Pro, Gemini 3 Flash / Pro, Ollama-hosted models (e.g. Kimi K2.5 cloud)
-- **Image (keyframes):** Imagen 3 / 4 / 4 Fast / 4 Ultra, Gemini Flash Image, Gemini 3 Pro Image
-- **Video:** Veo 2, Veo 3 / 3 Fast, Veo 3.1 / 3.1 Fast (+ GA variants), WAN 2.2 (via ComfyUI)
+- **Image (keyframes):** Gemini Flash Image (Nano Banana), Gemini 3 Pro Image; via ComfyUI Cloud: Qwen (txt2img, Image Edit, **Edit 2509 multi-ref**), Flux.1 Dev (+LoRA/refs), **FLUX.2 Klein** (up to 4 refs)
+- **Video:** Veo 2, Veo 3 / 3 Fast, Veo 3.1 / 3.1 Fast (+ GA variants); via ComfyUI Cloud: WAN 2.2 (i2v and **start+end keyframe FLF2V**), **LTX 2.3 FLF2V** (25fps, native audio), **Seedance 2.0 FLF2V** (paid, 4–15s, native audio)
 - **Voice & SFX:** ElevenLabs TTS and sound effects
 
-Native clip audio is supported on Veo 3+; WAN clips are silent, with narration and SFX mixed in at the production level. Preview models route automatically to the `global` Vertex AI endpoint.
+Native clip audio is supported on Veo 3+, LTX 2.3, and Seedance 2.0; WAN clips are silent, with narration and SFX mixed in at the production level. Reference-image keyframe generation (character/set identity from the Production Bible) works on Nano Banana, Qwen Edit 2509, and FLUX.2 Klein. Preview models route automatically to the `global` Vertex AI endpoint.
 
 ## Troubleshooting
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -37,6 +37,10 @@ dependencies = [
     "ultralytics>=8.3.0",
     "insightface>=0.7.3",
     "onnxruntime-gpu>=1.18.0",
+    # GPU face restoration (CodeFormer) + super-resolution (RealESRGAN) loaders.
+    # spandrel runs these PyTorch models without the legacy basicsr/facexlib deps.
+    "spandrel>=0.4.0",
+    "spandrel-extra-arches>=0.2.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/comfyui/test_new_models.py
+++ b/backend/tests/comfyui/test_new_models.py
@@ -1,0 +1,214 @@
+"""Live ComfyUI Cloud smoke tests for the new model workflows.
+
+Submits each new model's production workflow (built by the real
+vidpipe builders) to ComfyUI Cloud, polls, and downloads the output.
+
+Prerequisites:
+    - COMFY_UI_HOST and COMFY_UI_KEY set in .env at repo root
+    - vidpipe importable (pip install -e backend/ or PYTHONPATH=backend)
+    - Seedance is a PAID partner node: it only runs with
+      RUN_PAID_COMFY_TESTS=1 in the environment
+
+Usage:
+    cd <repo-root>
+    python backend/tests/comfyui/test_new_models.py qwen-2509
+    python backend/tests/comfyui/test_new_models.py flux2-klein
+    python backend/tests/comfyui/test_new_models.py ltx
+    RUN_PAID_COMFY_TESTS=1 python backend/tests/comfyui/test_new_models.py seedance
+    python backend/tests/comfyui/test_new_models.py all
+"""
+
+import asyncio
+import io
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.stdout.reconfigure(line_buffering=True)
+sys.stderr.reconfigure(line_buffering=True)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
+# Load .env from repo root
+_env_path = REPO_ROOT / ".env"
+if _env_path.exists():
+    for line in _env_path.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith("#") and "=" in line:
+            k, v = line.split("=", 1)
+            os.environ.setdefault(k.strip(), v.strip())
+
+sys.path.insert(0, str(REPO_ROOT / "backend"))
+
+from PIL import Image, ImageDraw  # noqa: E402
+
+from vidpipe.services.comfyui_client import (  # noqa: E402
+    ComfyUIClient,
+    build_flux2_klein_workflow,
+    build_ltx23_flf2v_workflow,
+    build_qwen_edit_2509_workflow,
+    build_seedance2_flf2v_workflow,
+    find_comfyui_image_output,
+    ltx_frames_for_duration,
+)
+from vidpipe.services.comfyui_adapter import find_video_output  # noqa: E402
+
+OUTPUT_DIR = Path(
+    os.environ.get("VIDPIPE_TEST_OUTPUT_DIR", "/tmp/vidpipe_test_outputs")
+)
+POLL_INTERVAL = 10
+POLL_TIMEOUT = 900
+
+
+def _test_image(color: tuple[int, int, int], label: str, size=(832, 480)) -> bytes:
+    img = Image.new("RGB", size, color)
+    draw = ImageDraw.Draw(img)
+    draw.ellipse([size[0] // 3, size[1] // 4, 2 * size[0] // 3, 3 * size[1] // 4],
+                 fill=(240, 220, 60))
+    draw.text((20, 20), label, fill=(255, 255, 255))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+async def _run_job(client: ComfyUIClient, workflow: dict, label: str,
+                   is_video: bool) -> bool:
+    prompt_id = await client.queue_prompt(workflow)
+    print(f"[{label}] queued: {prompt_id}")
+
+    t0 = time.time()
+    while True:
+        elapsed = time.time() - t0
+        if elapsed > POLL_TIMEOUT:
+            print(f"[{label}] TIMED OUT after {elapsed:.0f}s")
+            return False
+        status, error = await client.poll_status(prompt_id)
+        print(f"[{label}] [{elapsed:5.0f}s] status={status}")
+        if status in ("completed", "success", "done"):
+            break
+        if status in ("failed", "error", "cancelled"):
+            print(f"[{label}] FAILED: {error}")
+            return False
+        await asyncio.sleep(POLL_INTERVAL)
+
+    history = await client.get_history(prompt_id)
+    if is_video:
+        result = find_video_output(history, prompt_id)
+        ext = "mp4"
+    else:
+        result = find_comfyui_image_output(history, prompt_id)
+        ext = "png"
+    if not result:
+        print(f"[{label}] ERROR: no output found in history")
+        return False
+    filename, subfolder = result
+    data = await client.download_output(filename, subfolder=subfolder)
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    out = OUTPUT_DIR / f"new_model_{label}.{ext}"
+    out.write_bytes(data)
+    print(f"[{label}] SUCCESS → {out} ({len(data):,} bytes)")
+    return True
+
+
+async def test_qwen_2509(client: ComfyUIClient) -> bool:
+    ref1 = await client.upload_image(_test_image((40, 60, 120), "REF1"), "t2509_r1.png")
+    ref2 = await client.upload_image(_test_image((120, 40, 60), "REF2"), "t2509_r2.png")
+    wf = build_qwen_edit_2509_workflow(
+        prompt="Combine the subjects from both images into one scene on a beach at sunset",
+        image_filenames=[ref1, ref2],
+        seed=42,
+        output_width=1664,
+        output_height=928,
+    )
+    return await _run_job(client, wf, "qwen-2509", is_video=False)
+
+
+async def test_flux2_klein(client: ComfyUIClient) -> bool:
+    ref = await client.upload_image(_test_image((20, 100, 60), "REF"), "tklein_r1.png")
+    wf = build_flux2_klein_workflow(
+        prompt="The same yellow shape floating above a city skyline at night",
+        width=1344,
+        height=768,
+        seed=42,
+        reference_image_filenames=[ref],
+    )
+    return await _run_job(client, wf, "flux2-klein", is_video=False)
+
+
+async def test_ltx(client: ComfyUIClient) -> bool:
+    start = await client.upload_image(
+        _test_image((30, 30, 80), "START", size=(1280, 720)), "tltx_start.png")
+    end = await client.upload_image(
+        _test_image((80, 30, 30), "END", size=(1280, 720)), "tltx_end.png")
+    wf = build_ltx23_flf2v_workflow(
+        prompt="The yellow circle drifts slowly to the right as the light shifts from blue to red",
+        negative_prompt="blurry, distorted",
+        start_keyframe_filename=start,
+        end_keyframe_filename=end,
+        width=1280,
+        height=720,
+        frames=ltx_frames_for_duration(4),
+        seed=42,
+        generate_audio=True,
+    )
+    return await _run_job(client, wf, "ltx", is_video=True)
+
+
+async def test_seedance(client: ComfyUIClient) -> bool:
+    if os.environ.get("RUN_PAID_COMFY_TESTS") != "1":
+        print("[seedance] SKIPPED — set RUN_PAID_COMFY_TESTS=1 to run (bills real credits)")
+        return True
+    start = await client.upload_image(
+        _test_image((30, 30, 80), "START"), "tsd_start.png")
+    end = await client.upload_image(
+        _test_image((80, 30, 30), "END"), "tsd_end.png")
+    wf = build_seedance2_flf2v_workflow(
+        prompt="The yellow circle drifts to the right; gentle ambient sound",
+        first_frame_filename=start,
+        last_frame_filename=end,
+        duration=4,           # shortest duration to bound cost
+        resolution="480p",    # cheapest resolution
+        aspect_ratio="16:9",
+        seed=42,
+        generate_audio=True,
+    )
+    return await _run_job(client, wf, "seedance", is_video=True)
+
+
+TESTS = {
+    "qwen-2509": test_qwen_2509,
+    "flux2-klein": test_flux2_klein,
+    "ltx": test_ltx,
+    "seedance": test_seedance,
+}
+
+
+async def main():
+    which = sys.argv[1] if len(sys.argv) > 1 else "all"
+    targets = list(TESTS) if which == "all" else [which]
+    if any(t not in TESTS for t in targets):
+        print(f"Unknown test {which!r}. Options: {list(TESTS)} or 'all'")
+        sys.exit(2)
+
+    client = ComfyUIClient(
+        host=os.environ["COMFY_UI_HOST"].rstrip("/"),
+        api_key=os.environ["COMFY_UI_KEY"],
+    )
+    failures = []
+    try:
+        for name in targets:
+            ok = await TESTS[name](client)
+            if not ok:
+                failures.append(name)
+    finally:
+        await client.close()
+
+    if failures:
+        print(f"\nFAILED: {failures}")
+        sys.exit(1)
+    print("\nALL PASSED")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/test_clip_validation.py
+++ b/backend/tests/test_clip_validation.py
@@ -1,0 +1,180 @@
+"""Tests for degenerate-clip detection (vidpipe.services.clip_validation).
+
+Reproduces the observed ComfyUI Cloud failure mode: an MP4 whose first and
+last frames match the FLF2V conditioning keyframes but whose middle frames
+are noise. Synthetic clips are built with cv2 so tests are self-contained.
+"""
+
+import io
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from vidpipe.services.clip_validation import validate_clip_integrity
+
+cv2 = pytest.importorskip("cv2")
+
+W, H, FPS, N_FRAMES = 320, 192, 16, 48
+RNG = np.random.default_rng(42)
+
+
+def _scene_frame(t: float) -> np.ndarray:
+    """A structured 'real' frame: gradient background + moving square."""
+    frame = np.zeros((H, W, 3), dtype=np.uint8)
+    xs = np.linspace(40, 200, W, dtype=np.uint8)
+    frame[:, :, 0] = xs[None, :]
+    frame[:, :, 1] = np.linspace(60, 180, H, dtype=np.uint8)[:, None]
+    # Slowly moving square (continuous motion between frames)
+    x = int(20 + t * 150) % (W - 60)
+    y = int(30 + t * 60) % (H - 60)
+    frame[y : y + 50, x : x + 50] = (220, 90, 40)
+    return frame
+
+
+def _noise_frame() -> np.ndarray:
+    return RNG.integers(0, 255, size=(H, W, 3), dtype=np.uint8)
+
+
+def _encode(frames: list[np.ndarray], tmp_path) -> bytes:
+    path = str(tmp_path / "clip.mp4")
+    writer = cv2.VideoWriter(
+        path, cv2.VideoWriter_fourcc(*"mp4v"), FPS, (W, H)
+    )
+    for f in frames:
+        writer.write(cv2.cvtColor(f, cv2.COLOR_RGB2BGR))
+    writer.release()
+    with open(path, "rb") as fh:
+        return fh.read()
+
+
+def _png(frame: np.ndarray) -> bytes:
+    buf = io.BytesIO()
+    Image.fromarray(frame).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@pytest.fixture(scope="module")
+def good_frames() -> list[np.ndarray]:
+    return [_scene_frame(i / FPS) for i in range(N_FRAMES)]
+
+
+def test_good_clip_passes(tmp_path, good_frames):
+    video = _encode(good_frames, tmp_path)
+    result = validate_clip_integrity(
+        video,
+        start_frame_bytes=_png(good_frames[0]),
+        end_frame_bytes=_png(good_frames[-1]),
+    )
+    assert result.ok, result.detail
+
+
+def test_noise_middle_with_good_conditioning_frames_fails(tmp_path, good_frames):
+    """The exact observed corruption: pinned first/last frames, noise between."""
+    frames = (
+        [good_frames[0]]
+        + [_noise_frame() for _ in range(N_FRAMES - 2)]
+        + [good_frames[-1]]
+    )
+    video = _encode(frames, tmp_path)
+    result = validate_clip_integrity(
+        video,
+        start_frame_bytes=_png(good_frames[0]),
+        end_frame_bytes=_png(good_frames[-1]),
+    )
+    assert not result.ok
+    assert "noise_frames" in result.detail
+
+
+def test_all_noise_clip_fails(tmp_path, good_frames):
+    frames = [_noise_frame() for _ in range(N_FRAMES)]
+    video = _encode(frames, tmp_path)
+    result = validate_clip_integrity(
+        video, start_frame_bytes=_png(good_frames[0])
+    )
+    assert not result.ok
+
+
+def test_wrong_video_fails_start_anchor(tmp_path, good_frames):
+    """A coherent clip that is not the one we asked for."""
+    # Inverted scene — continuous, but unrelated to the keyframe
+    frames = [255 - _scene_frame(0.5 + i / FPS) for i in range(N_FRAMES)]
+    video = _encode(frames, tmp_path)
+    result = validate_clip_integrity(
+        video, start_frame_bytes=_png(good_frames[0])
+    )
+    assert not result.ok
+    assert "start_frame_mismatch" in result.detail
+
+
+def test_brief_dark_occlusion_passes(tmp_path, good_frames):
+    """A near-black moment (object crossing the lens) is not corruption."""
+    frames = list(good_frames)
+    for i in range(20, 26):
+        # Dark, slightly textured frame — like a real occlusion
+        dark = (good_frames[i].astype(np.float64) * 0.06).astype(np.uint8)
+        frames[i] = dark
+    video = _encode(frames, tmp_path)
+    result = validate_clip_integrity(
+        video,
+        start_frame_bytes=_png(good_frames[0]),
+        end_frame_bytes=_png(good_frames[-1]),
+    )
+    assert result.ok, result.detail
+
+
+def test_good_clip_without_keyframes_passes(tmp_path, good_frames):
+    video = _encode(good_frames, tmp_path)
+    result = validate_clip_integrity(video)
+    assert result.ok, result.detail
+
+
+def test_undecodable_video_fails():
+    result = validate_clip_integrity(b"not a video at all")
+    assert not result.ok
+    assert "undecodable" in result.detail
+
+
+def test_moving_clip_reports_more_motion_than_frozen(tmp_path, good_frames):
+    """A moving subject reports clearly higher motion than a held frame.
+
+    (Absolute scale is lower for synthetic clips than real footage; the
+    real-world clip_min_motion threshold is calibrated separately. What
+    matters here is that moving > frozen.)
+    """
+    moving_dir = tmp_path / "moving"
+    frozen_dir = tmp_path / "frozen"
+    moving_dir.mkdir()
+    frozen_dir.mkdir()
+    moving = validate_clip_integrity(_encode(good_frames, moving_dir))
+    frozen = validate_clip_integrity(
+        _encode([good_frames[0]] * N_FRAMES, frozen_dir)
+    )
+    assert moving.ok and frozen.ok
+    assert moving.motion_mean > frozen.motion_mean
+
+
+def test_frozen_clip_reports_near_zero_motion_but_still_ok(tmp_path, good_frames):
+    """A held single frame is near-zero motion — reported, NOT failed.
+
+    Motion is a quality signal; the integrity gate must still pass so the
+    caller (video_gen) decides whether to escalate, not clip_validation.
+    """
+    frozen = [good_frames[0]] * N_FRAMES
+    video = _encode(frozen, tmp_path)
+    result = validate_clip_integrity(video)
+    assert result.ok, result.detail
+    assert result.motion_mean < 1.0, result.motion_mean
+
+
+def test_motion_metric_orders_clips(tmp_path, good_frames):
+    """Faster subject motion yields a strictly higher motion_mean."""
+    slow_dir = tmp_path / "slow"
+    fast_dir = tmp_path / "fast"
+    slow_dir.mkdir()
+    fast_dir.mkdir()
+    slow = [_scene_frame(i / FPS * 0.2) for i in range(N_FRAMES)]
+    fast = [_scene_frame(i / FPS * 3.0) for i in range(N_FRAMES)]
+    slow_motion = validate_clip_integrity(_encode(slow, slow_dir)).motion_mean
+    fast_motion = validate_clip_integrity(_encode(fast, fast_dir)).motion_mean
+    assert fast_motion > slow_motion

--- a/backend/tests/test_comfyui_adapter.py
+++ b/backend/tests/test_comfyui_adapter.py
@@ -1,0 +1,215 @@
+"""Tests for ComfyUIVideoAdapter model dispatch and the video spec registry."""
+
+import io
+
+import pytest
+from PIL import Image
+
+from vidpipe.pipeline.video_gen import COMFYUI_VIDEO_MODELS
+from vidpipe.services.comfyui_adapter import (
+    COMFY_VIDEO_SPECS,
+    ComfyUIVideoAdapter,
+)
+
+
+class MockComfyClient:
+    """Records uploads and the queued workflow without any network I/O."""
+
+    def __init__(self):
+        self.uploads: list[str] = []
+        self.queued: dict | None = None
+
+    async def upload_image(self, image_bytes: bytes, filename: str) -> str:
+        self.uploads.append(filename)
+        return filename
+
+    async def queue_prompt(self, workflow: dict) -> str:
+        self.queued = workflow
+        return "test-prompt-id"
+
+
+def _png(width: int = 832, height: int = 480) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), (40, 80, 120)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@pytest.fixture
+def png_bytes() -> bytes:
+    return _png()
+
+
+def _node_types(workflow: dict) -> set[str]:
+    return {node["class_type"] for node in workflow.values()}
+
+
+def test_every_routed_model_has_a_spec() -> None:
+    assert set(COMFY_VIDEO_SPECS) == COMFYUI_VIDEO_MODELS
+
+
+def test_spec_durations() -> None:
+    # WAN ignores the requested duration (always 81 frames @ 16fps)
+    assert COMFY_VIDEO_SPECS["wan-2.2-i2v"].clip_duration(8) == pytest.approx(81 / 16)
+    assert COMFY_VIDEO_SPECS["wan-2.2-flf2v"].clip_duration(8) == pytest.approx(81 / 16)
+    # LTX and Seedance honor it
+    assert COMFY_VIDEO_SPECS["ltx-2.3-flf2v"].clip_duration(8) == 8.0
+    assert COMFY_VIDEO_SPECS["seedance-2.0-flf2v"].clip_duration(12) == 12.0
+
+
+@pytest.mark.asyncio
+async def test_wan_flf2v_submits_flf_workflow_with_char_refs(png_bytes) -> None:
+    client = MockComfyClient()
+    adapter = ComfyUIVideoAdapter(client)
+
+    op_id = await adapter.submit(
+        video_prompt="orbit the subject",
+        start_frame_bytes=png_bytes,
+        end_frame_bytes=png_bytes,
+        char_ref_bytes=[png_bytes, png_bytes],
+        aspect_ratio="16:9",
+        seed=11,
+        shot_index=2,
+        video_model="wan-2.2-flf2v",
+        duration_seconds=5,
+    )
+
+    assert op_id == "comfyui:test-prompt-id"
+    assert "shot_2_start.png" in client.uploads
+    assert "shot_2_end.png" in client.uploads
+    assert "shot_2_charref_1.png" in client.uploads
+    assert "shot_2_charref_2.png" in client.uploads
+    assert "WanFirstLastFrameToVideo" in _node_types(client.queued)
+    # Framing-safety prefix applied per spec
+    assert client.queued["93"]["inputs"]["text"].startswith("Keep the subject")
+
+
+@pytest.mark.asyncio
+async def test_wan_flf2v_missing_end_frame_falls_back_to_i2v(png_bytes) -> None:
+    client = MockComfyClient()
+    adapter = ComfyUIVideoAdapter(client)
+
+    await adapter.submit(
+        video_prompt="pan",
+        start_frame_bytes=png_bytes,
+        end_frame_bytes=None,
+        char_ref_bytes=[],
+        aspect_ratio="16:9",
+        seed=0,
+        shot_index=0,
+        video_model="wan-2.2-flf2v",
+    )
+
+    types = _node_types(client.queued)
+    assert "WanImageToVideo" in types
+    assert "WanFirstLastFrameToVideo" not in types
+
+
+@pytest.mark.asyncio
+async def test_wan_i2v_ignores_end_frame(png_bytes) -> None:
+    client = MockComfyClient()
+    adapter = ComfyUIVideoAdapter(client)
+
+    await adapter.submit(
+        video_prompt="pan",
+        start_frame_bytes=png_bytes,
+        end_frame_bytes=png_bytes,  # provided but unsupported
+        char_ref_bytes=[],
+        aspect_ratio="16:9",
+        seed=0,
+        shot_index=0,
+        video_model="wan-2.2-i2v",
+    )
+
+    assert "WanImageToVideo" in _node_types(client.queued)
+    assert not any("end" in fn for fn in client.uploads)
+
+
+@pytest.mark.asyncio
+async def test_ltx_resizes_keyframes_and_sets_frames(png_bytes) -> None:
+    client = MockComfyClient()
+    adapter = ComfyUIVideoAdapter(client)
+
+    await adapter.submit(
+        video_prompt="dolly in",
+        start_frame_bytes=png_bytes,
+        end_frame_bytes=png_bytes,
+        char_ref_bytes=[png_bytes],  # ignored: no char-ref support
+        aspect_ratio="16:9",
+        seed=3,
+        shot_index=1,
+        video_model="ltx-2.3-flf2v",
+        duration_seconds=6,
+        audio_enabled=True,
+    )
+
+    wf = client.queued
+    assert wf["16"]["inputs"]["width"] == 1280
+    assert wf["16"]["inputs"]["height"] == 720
+    assert wf["16"]["inputs"]["length"] == 151  # 6s * 25fps + 1
+    assert wf["30"]["inputs"]["audio"] == ["29", 0]
+    assert not any("charref" in fn for fn in client.uploads)
+
+
+@pytest.mark.asyncio
+async def test_ltx_audio_disabled(png_bytes) -> None:
+    client = MockComfyClient()
+    adapter = ComfyUIVideoAdapter(client)
+
+    await adapter.submit(
+        video_prompt="dolly in",
+        start_frame_bytes=png_bytes,
+        end_frame_bytes=None,
+        char_ref_bytes=[],
+        aspect_ratio="9:16",
+        seed=3,
+        shot_index=1,
+        video_model="ltx-2.3-flf2v",
+        duration_seconds=4,
+        audio_enabled=False,
+    )
+
+    wf = client.queued
+    assert wf["16"]["inputs"]["width"] == 720
+    assert "audio" not in wf["30"]["inputs"]
+
+
+@pytest.mark.asyncio
+async def test_seedance_clamps_duration_and_maps_ratio(png_bytes) -> None:
+    client = MockComfyClient()
+    adapter = ComfyUIVideoAdapter(client)
+
+    await adapter.submit(
+        video_prompt="fly through",
+        start_frame_bytes=png_bytes,
+        end_frame_bytes=None,
+        char_ref_bytes=[],
+        aspect_ratio="9:16",
+        seed=1,
+        shot_index=4,
+        video_model="seedance-2.0-flf2v",
+        duration_seconds=20,  # above max — clamped to 15
+        audio_enabled=True,
+    )
+
+    node = client.queued["3"]["inputs"]
+    assert node["model.duration"] == 15
+    assert node["model.ratio"] == "9:16"
+    assert node["model.generate_audio"] is True
+    assert "last_frame" not in node
+
+
+@pytest.mark.asyncio
+async def test_unknown_model_raises(png_bytes) -> None:
+    adapter = ComfyUIVideoAdapter(MockComfyClient())
+
+    with pytest.raises(ValueError, match="Unknown ComfyUI video model"):
+        await adapter.submit(
+            video_prompt="x",
+            start_frame_bytes=png_bytes,
+            end_frame_bytes=None,
+            char_ref_bytes=[],
+            aspect_ratio="16:9",
+            seed=0,
+            shot_index=0,
+            video_model="not-a-model",
+        )

--- a/backend/tests/test_comfyui_client.py
+++ b/backend/tests/test_comfyui_client.py
@@ -1,6 +1,13 @@
+import pytest
+
 from vidpipe.services.comfyui_client import (
+    build_flux2_klein_workflow,
+    build_ltx23_flf2v_workflow,
+    build_qwen_edit_2509_workflow,
     build_qwen_image_edit_workflow,
     build_qwen_txt2img_workflow,
+    build_seedance2_flf2v_workflow,
+    ltx_frames_for_duration,
 )
 
 
@@ -18,3 +25,199 @@ def test_qwen_image_edit_workflow_defaults_null_seed_to_zero() -> None:
     )
 
     assert workflow["102:3"]["inputs"]["seed"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Qwen Image Edit 2509 (multi-ref)
+# ---------------------------------------------------------------------------
+
+def test_qwen_edit_2509_single_image_prunes_unused_refs() -> None:
+    wf = build_qwen_edit_2509_workflow(
+        prompt="edit", image_filenames=["a.png"], seed=42,
+    )
+
+    assert wf["10"]["inputs"]["image"] == "a.png"
+    assert "11" not in wf and "12" not in wf
+    for encode_node in ("110", "111"):
+        assert "image2" not in wf[encode_node]["inputs"]
+        assert "image3" not in wf[encode_node]["inputs"]
+    # Edit mode: latent follows image1 via VAEEncode, empty latent pruned
+    assert wf["3"]["inputs"]["latent_image"] == ["88", 0]
+    assert "107" not in wf
+    assert wf["3"]["inputs"]["seed"] == 42
+
+
+def test_qwen_edit_2509_three_images_kept() -> None:
+    wf = build_qwen_edit_2509_workflow(
+        prompt="compose", image_filenames=["a.png", "b.png", "c.png"], seed=1,
+    )
+
+    assert wf["11"]["inputs"]["image"] == "b.png"
+    assert wf["12"]["inputs"]["image"] == "c.png"
+    assert wf["110"]["inputs"]["image2"] == ["11", 0]
+    assert wf["110"]["inputs"]["image3"] == ["12", 0]
+
+
+def test_qwen_edit_2509_generation_mode_uses_empty_latent() -> None:
+    wf = build_qwen_edit_2509_workflow(
+        prompt="compose", image_filenames=["a.png", "b.png"], seed=1,
+        output_width=1664, output_height=928,
+    )
+
+    assert wf["3"]["inputs"]["latent_image"] == ["107", 0]
+    assert wf["107"]["inputs"]["width"] == 1664
+    assert wf["107"]["inputs"]["height"] == 928
+
+
+def test_qwen_edit_2509_rejects_empty_and_excess_images() -> None:
+    with pytest.raises(ValueError):
+        build_qwen_edit_2509_workflow(prompt="x", image_filenames=[], seed=0)
+    with pytest.raises(ValueError):
+        build_qwen_edit_2509_workflow(
+            prompt="x", image_filenames=["1", "2", "3", "4"], seed=0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# FLUX.2 Klein
+# ---------------------------------------------------------------------------
+
+def test_flux2_klein_zero_refs_is_plain_txt2img() -> None:
+    wf = build_flux2_klein_workflow(prompt="a cat", width=1344, height=768, seed=5)
+
+    # CFGGuider wired directly to the encoders
+    assert wf["76"]["inputs"]["positive"] == ["74", 0]
+    assert wf["76"]["inputs"]["negative"] == ["82", 0]
+    # All ref machinery pruned
+    for node_id in ("20", "30", "40", "50", "60", "23", "33", "43", "53", "63"):
+        assert node_id not in wf
+    assert wf["66"]["inputs"]["width"] == 1344
+    assert wf["67"]["inputs"]["height"] == 768
+    assert wf["73"]["inputs"]["noise_seed"] == 5
+
+
+def test_flux2_klein_two_refs_rewires_guider_to_chain_end() -> None:
+    wf = build_flux2_klein_workflow(
+        prompt="a cat", seed=5,
+        reference_image_filenames=["r1.png", "r2.png"],
+    )
+
+    assert wf["20"]["inputs"]["image"] == "r1.png"
+    assert wf["21"]["inputs"]["image"] == "r2.png"
+    assert "22" not in wf and "23" not in wf
+    # Positive chain ends at ref-2 ReferenceLatent (51), negative at 61
+    assert wf["76"]["inputs"]["positive"] == ["51", 0]
+    assert wf["76"]["inputs"]["negative"] == ["61", 0]
+    # Chain integrity: 51 consumes 50, which consumes the text encoder
+    assert wf["51"]["inputs"]["conditioning"] == ["50", 0]
+    assert wf["50"]["inputs"]["conditioning"] == ["74", 0]
+
+
+def test_flux2_klein_rejects_more_than_four_refs() -> None:
+    with pytest.raises(ValueError):
+        build_flux2_klein_workflow(
+            prompt="x", seed=0,
+            reference_image_filenames=["1", "2", "3", "4", "5"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# LTX-2.3 FLF2V
+# ---------------------------------------------------------------------------
+
+def test_ltx_frames_for_duration() -> None:
+    assert ltx_frames_for_duration(4) == 101
+    assert ltx_frames_for_duration(6) == 151
+    assert ltx_frames_for_duration(10) == 251
+
+
+def test_ltx_flf2v_with_end_frame() -> None:
+    wf = build_ltx23_flf2v_workflow(
+        prompt="pan", negative_prompt="bad",
+        start_keyframe_filename="s.png", end_keyframe_filename="e.png",
+        width=1280, height=720, frames=151, seed=7,
+    )
+
+    assert wf["4"]["inputs"]["text"] == "pan"
+    assert wf["13"]["inputs"]["image"] == "e.png"
+    assert wf["16"]["inputs"]["length"] == 151
+    assert wf["19"]["inputs"]["frames_number"] == 151
+    assert wf["17"]["inputs"]["frame_idx"] == 0
+    assert wf["18"]["inputs"]["frame_idx"] == -1
+    # Audio muxed by default
+    assert wf["30"]["inputs"]["audio"] == ["29", 0]
+
+
+def test_ltx_flf2v_without_end_frame_splices_guide_chain() -> None:
+    wf = build_ltx23_flf2v_workflow(
+        prompt="pan", negative_prompt="bad",
+        start_keyframe_filename="s.png", seed=7,
+    )
+
+    for node_id in ("13", "15", "18"):
+        assert node_id not in wf
+    # Downstream consumers rewired to the first guide
+    assert wf["20"]["inputs"]["video_latent"] == ["17", 2]
+    assert wf["22"]["inputs"]["positive"] == ["17", 0]
+    assert wf["22"]["inputs"]["negative"] == ["17", 1]
+    assert wf["27"]["inputs"]["positive"] == ["17", 0]
+
+
+def test_ltx_flf2v_audio_disabled_drops_audio_mux() -> None:
+    wf = build_ltx23_flf2v_workflow(
+        prompt="pan", negative_prompt="bad",
+        start_keyframe_filename="s.png", end_keyframe_filename="e.png",
+        seed=7, generate_audio=False,
+    )
+
+    assert "audio" not in wf["30"]["inputs"]
+    assert "29" not in wf
+
+
+# ---------------------------------------------------------------------------
+# Seedance 2.0 FLF2V
+# ---------------------------------------------------------------------------
+
+def test_seedance_flf2v_injects_dotted_dynamic_inputs() -> None:
+    wf = build_seedance2_flf2v_workflow(
+        prompt="drone shot", first_frame_filename="f.png",
+        last_frame_filename="l.png", duration=8, resolution="720p",
+        aspect_ratio="9:16", seed=9, generate_audio=True,
+    )
+
+    node = wf["3"]["inputs"]
+    assert node["model"] == "Seedance 2.0"
+    assert node["model.prompt"] == "drone shot"
+    assert node["model.resolution"] == "720p"
+    assert node["model.ratio"] == "9:16"
+    assert node["model.duration"] == 8
+    assert node["model.generate_audio"] is True
+    assert node["seed"] == 9
+    assert node["first_frame"] == ["1", 0]
+    assert node["last_frame"] == ["2", 0]
+    assert wf["2"]["inputs"]["image"] == "l.png"
+
+
+def test_seedance_flf2v_without_last_frame() -> None:
+    wf = build_seedance2_flf2v_workflow(
+        prompt="x", first_frame_filename="f.png", duration=4, seed=0,
+    )
+
+    assert "2" not in wf
+    assert "last_frame" not in wf["3"]["inputs"]
+
+
+def test_seedance_flf2v_validates_duration_and_ratio() -> None:
+    with pytest.raises(ValueError):
+        build_seedance2_flf2v_workflow(
+            prompt="x", first_frame_filename="f.png", duration=3,
+        )
+    with pytest.raises(ValueError):
+        build_seedance2_flf2v_workflow(
+            prompt="x", first_frame_filename="f.png", duration=16,
+        )
+    with pytest.raises(ValueError):
+        build_seedance2_flf2v_workflow(
+            prompt="x", first_frame_filename="f.png", duration=5,
+            aspect_ratio="2:1",
+        )

--- a/backend/tests/test_cyberpunk_seedance_e2e.py
+++ b/backend/tests/test_cyberpunk_seedance_e2e.py
@@ -1,0 +1,476 @@
+"""Opt-in cloud E2E: a 1-minute cyberpunk short with Seedance 2.0 + FLUX.2 Klein + Gemini.
+
+Mirrors the NASA documentary E2E flow but:
+- Reuses the existing Asset Library actor "Brandon" (migrated from the legacy
+  Brandon Manifest production bible) instead of creating actors from downloads.
+- Cyberpunk megacity concept (Johnny Mnemonic energy): Brandon as a data
+  courier crossing a neon city with stolen corporate data.
+- Models: seedance-2.0-flf2v video (native audio ON), flux-2-klein keyframes,
+  Gemini text + vision.
+- 1-minute target: 3 scenes x 2 shots x 10s.
+
+Run only when you intentionally want to spend provider credits:
+
+    VIDPIPE_RUN_CYBERPUNK_E2E=1 pytest backend/tests/test_cyberpunk_seedance_e2e.py -q -s
+
+Note: seedance-2.0-flf2v is a paid ByteDance partner node — the ComfyUI Cloud
+account must have partner-node (API node) access or every video job fails with
+"Unauthorized: Please login first to use this node".
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("VIDPIPE_RUN_CYBERPUNK_E2E") != "1",
+    reason="Set VIDPIPE_RUN_CYBERPUNK_E2E=1 to run the paid cloud cyberpunk E2E.",
+)
+
+API_BASE = os.getenv("VIDPIPE_E2E_API_BASE", "http://localhost:8100").rstrip("/")
+TEXT_MODEL = os.getenv("VIDPIPE_CYBERPUNK_E2E_TEXT_MODEL", "gemini-3.5-flash")
+VISION_MODEL = os.getenv("VIDPIPE_CYBERPUNK_E2E_VISION_MODEL", "gemini-3.5-flash")
+IMAGE_MODEL = os.getenv("VIDPIPE_CYBERPUNK_E2E_IMAGE_MODEL", "flux-2-klein")
+VIDEO_MODEL = os.getenv("VIDPIPE_CYBERPUNK_E2E_VIDEO_MODEL", "seedance-2.0-flf2v")
+ACTOR_NAME = os.getenv("VIDPIPE_CYBERPUNK_E2E_ACTOR", "Brandon")
+SCENE_TIMEOUT_SECONDS = int(os.getenv("VIDPIPE_CYBERPUNK_E2E_SCENE_TIMEOUT", "3600"))
+SCENE_COUNT = int(os.getenv("VIDPIPE_CYBERPUNK_E2E_SCENE_COUNT", "3"))
+CLIP_DURATION_SECONDS = int(os.getenv("VIDPIPE_CYBERPUNK_E2E_CLIP_DURATION", "10"))
+SHOTS_PER_SCENE = int(os.getenv("VIDPIPE_CYBERPUNK_E2E_SHOTS_PER_SCENE", "2"))
+AUDIO_ENABLED = os.getenv("VIDPIPE_CYBERPUNK_E2E_AUDIO", "1") == "1"
+
+
+def _api(path: str) -> str:
+    return f"{API_BASE}/api{path}"
+
+
+def _assert_ok(response: httpx.Response) -> dict:
+    assert response.status_code < 400, f"{response.request.method} {response.url}: {response.text[:1000]}"
+    if response.content:
+        return response.json()
+    return {}
+
+
+def _preflight(client: httpx.Client) -> dict:
+    settings = _assert_ok(client.get(_api("/settings")))
+    missing = []
+    if not settings.get("has_comfyui_key") or not settings.get("comfyui_host"):
+        missing.append("ComfyUI host/API key")
+    if not settings.get("has_elevenlabs_key") or not settings.get("default_voice_id"):
+        missing.append("ElevenLabs key/default voice")
+    assert not missing, f"Preflight failed; configure: {', '.join(missing)}"
+    return settings
+
+
+def _find_actor(client: httpx.Client, name: str) -> dict:
+    actors = _assert_ok(client.get(_api("/asset-library/actors")))
+    if isinstance(actors, dict):
+        actors = actors.get("actors", actors.get("items", []))
+    matches = [a for a in actors if a["name"] == name]
+    assert matches, f"Actor {name!r} not found in asset library — migrate it first"
+    # Newest match wins (the freshly migrated one)
+    return matches[-1]
+
+
+def _bind_actor(
+    client: httpx.Client,
+    *,
+    actor_id: str,
+    bible_id: str,
+    tag: str,
+    character_name: str,
+    character_description: str,
+    role: str,
+    voice_profile_id: str | None,
+    wardrobe_label: str,
+    wardrobe_description: str,
+) -> str:
+    wardrobe_preset = _assert_ok(client.post(
+        _api(f"/asset-library/actors/{actor_id}/wardrobe-presets"),
+        json={"label": wardrobe_label, "description": wardrobe_description},
+    ))
+    binding = _assert_ok(client.post(
+        _api(f"/production-bibles/{bible_id}/cast"),
+        json={
+            "actor_id": actor_id,
+            "tag": tag,
+            "character_name": character_name,
+            "character_description": character_description,
+            "role": role,
+            "voice_profile_id": voice_profile_id,
+            "prompt_tags": [tag, "cyberpunk"],
+        },
+    ))
+    _assert_ok(client.post(
+        _api(f"/cast-bindings/{binding['id']}/looks"),
+        json={
+            "wardrobe_preset_id": wardrobe_preset["id"],
+            "tag": f"{tag}_LOOK",
+            "is_default": True,
+        },
+    ))
+    return binding["id"]
+
+
+def _seed_screenplay(client: httpx.Client, production_id: str) -> dict:
+    _assert_ok(client.get(_api(f"/productions/{production_id}/screenplay")))
+    return _assert_ok(client.put(
+        _api(f"/productions/{production_id}/screenplay"),
+        json={
+            "title": "Wet Circuit",
+            "genre": "Cyberpunk noir short",
+            "logline": (
+                "A freelance data courier carries three hundred megabytes of stolen "
+                "corporate memory across a neon megacity in one rain-soaked night."
+            ),
+            "treatment": (
+                "Night in the megacity. BRANDON, a veteran data courier with a wet-wired "
+                "implant behind his ear, threads through a neon street market while corporate "
+                "hunter-drones sweep the crowds. He reaches a hacker den buried under a noodle "
+                "bar and jacks into a console to verify the cargo before the handoff. With the "
+                "data confirmed and the buyers inbound, he climbs to a rooftop above the skyline "
+                "as dawn threatens, and lets the city decide whether he gets to keep his head."
+            ),
+            "character_breakdowns": [
+                {"tag": "NARRATOR", "name": "Narrator", "role": "noir voiceover"},
+                {"tag": "BRANDON", "name": "Brandon", "role": "data courier protagonist"},
+            ],
+            "scene_breakdown": [
+                {
+                    "scene_number": 1,
+                    "slugline": "EXT. @NEON_MARKET - NIGHT",
+                    "intent": (
+                        "Brandon moves through a rain-slick neon street market — holographic "
+                        "signage, steam vents, dense crowds — keeping the implant hidden."
+                    ),
+                    "characters_present": ["BRANDON"],
+                    "set_ref": "NEON_MARKET",
+                    "props_required": ["CYBERDECK"],
+                    "emotional_beat": "Paranoia under sensory overload.",
+                },
+                {
+                    "scene_number": 2,
+                    "slugline": "INT. @DATA_DEN - NIGHT",
+                    "intent": (
+                        "In a cramped hacker den beneath a noodle bar, Brandon jacks the "
+                        "implant into a battered cyberdeck and watches the stolen data unfold "
+                        "in cascading glyphs."
+                    ),
+                    "characters_present": ["BRANDON"],
+                    "set_ref": "DATA_DEN",
+                    "props_required": ["CYBERDECK"],
+                    "emotional_beat": "Focus and dread — the cargo is bigger than the job.",
+                },
+                {
+                    "scene_number": 3,
+                    "slugline": "EXT. @ROOFTOP_SKYLINE - PRE-DAWN",
+                    "intent": (
+                        "Brandon stands on a rooftop above the endless megacity as hunter-"
+                        "drones trace the streets below; the handoff window opens with the "
+                        "first gray light."
+                    ),
+                    "characters_present": ["BRANDON"],
+                    "set_ref": "ROOFTOP_SKYLINE",
+                    "props_required": ["CYBERDECK"],
+                    "emotional_beat": "Defiance at the edge of escape.",
+                },
+            ],
+            "script": (
+                "NARRATOR: Three hundred megabytes of somebody else's memory, riding wet-wired behind my ear.\n"
+                "NARRATOR: The market doesn't care what you carry. It only cares that you keep moving.\n"
+                "NARRATOR: Down under the noodle bar, the den smelled like ozone and old solder.\n"
+                "NARRATOR: The data unfolded like a city of its own — and half of it wasn't supposed to exist.\n"
+                "NARRATOR: By rooftop light the drones were still hunting yesterday's ghost.\n"
+                "NARRATOR: Come dawn, the city keeps the data. With luck, I keep my head."
+            ),
+            "shot_list": [
+                {"scene_number": 1, "shot_number": 1, "description": "Wide neon market street in rain, Brandon weaving through the crowd under holographic signs."},
+                {"scene_number": 1, "shot_number": 2, "description": "Tracking close-up of Brandon's face lit by shifting neon, eyes scanning for drones."},
+                {"scene_number": 2, "shot_number": 1, "description": "Brandon descends into the cramped hacker den, cables and CRT glow everywhere."},
+                {"scene_number": 2, "shot_number": 2, "description": "Close on Brandon jacked into the cyberdeck, data glyphs reflecting on his glasses."},
+                {"scene_number": 3, "shot_number": 1, "description": "Brandon steps onto the rooftop, endless megacity skyline with searchlight drones below."},
+                {"scene_number": 3, "shot_number": 2, "description": "Wide hero shot of Brandon at the rooftop edge as pre-dawn light breaks over the towers."},
+            ],
+            "text_model": TEXT_MODEL,
+        },
+    ))
+
+
+def _wait_for_scene(client: httpx.Client, scene_id: str) -> dict:
+    deadline = time.monotonic() + SCENE_TIMEOUT_SECONDS
+    last = {}
+    while time.monotonic() < deadline:
+        last = _assert_ok(client.get(_api(f"/scenes/{scene_id}"), timeout=60))
+        if last["status"] == "complete":
+            return last
+        if last["status"] in {"failed", "stopped"}:
+            raise AssertionError(f"Scene {scene_id} ended as {last['status']}: {last.get('error_message')}")
+        time.sleep(20)
+    raise AssertionError(f"Timed out waiting for scene {scene_id}; last state: {last}")
+
+
+def _assert_master_has_audio(path: Path) -> None:
+    if shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None:
+        pytest.skip("ffmpeg and ffprobe are required to validate the master video")
+    streams = subprocess.run(
+        ["ffprobe", "-v", "error", "-show_streams", str(path)],
+        check=True, capture_output=True, text=True,
+    ).stdout
+    assert "codec_type=video" in streams
+    assert "codec_type=audio" in streams
+    volume = subprocess.run(
+        ["ffmpeg", "-hide_banner", "-i", str(path), "-af", "volumedetect", "-f", "null", "-"],
+        check=True, capture_output=True, text=True,
+    ).stderr
+    assert "mean_volume: -inf" not in volume
+    assert "max_volume: -inf" not in volume
+
+
+def test_cyberpunk_seedance_cloud_e2e(tmp_path):
+    with httpx.Client(timeout=httpx.Timeout(60, read=600), follow_redirects=True) as client:
+        settings = _preflight(client)
+        default_voice_id = settings["default_voice_id"]
+
+        actor = _find_actor(client, ACTOR_NAME)
+        actor_id = actor["id"]
+
+        # cast_bindings has a unique (production_bible_id, actor_id) constraint,
+        # so the narrator needs its own voice-only actor rather than reusing
+        # the on-screen Brandon actor.
+        narrator_actor = _assert_ok(client.post(
+            _api("/asset-library/actors"),
+            json={
+                "name": "Brandon Narrator (voice)",
+                "description": "Voice-only noir narrator for the Wet Circuit cyberpunk short. Never appears on screen.",
+                "base_appearance_prompt": "Voice-only narrator; no on-screen appearance.",
+                "prompt_tags": ["narrator", "voice-only"],
+            },
+        ))
+        narrator_actor_id = narrator_actor["id"]
+        voice = _assert_ok(client.post(
+            _api(f"/asset-library/actors/{narrator_actor_id}/voice-profiles"),
+            json={
+                "voice_id": default_voice_id,
+                "adapter_type": "ELEVENLABS",
+                "style_notes": "Low, dry cyberpunk noir voiceover. World-weary, deliberate pacing.",
+            },
+        ))
+        voice_profile_id = voice["id"]
+
+        bible = _assert_ok(client.post(
+            _api("/production-bibles"),
+            json={
+                "name": f"Wet Circuit Bible {int(time.time())}",
+                "description": "Cyberpunk noir short — Brandon as a data courier in a neon megacity.",
+                "category": "FULL_PRODUCTION",
+                "tags": ["cyberpunk", "noir", "e2e", "seedance"],
+            },
+        ))
+        bible_id = bible["production_bible_id"]
+        production = _assert_ok(client.post(
+            _api("/productions"),
+            json={
+                "name": f"Wet Circuit (Cyberpunk E2E) {int(time.time())}",
+                "description": (
+                    f"Opt-in cloud E2E production using {TEXT_MODEL}, {IMAGE_MODEL}, "
+                    f"{VIDEO_MODEL}, and ElevenLabs narration."
+                ),
+                "tags": ["e2e", "cyberpunk", "seedance"],
+            },
+        ))
+        production_id = production["id"]
+        _assert_ok(client.put(
+            _api(f"/productions/{production_id}"),
+            json={"production_bible_id": bible_id},
+        ))
+
+        _bind_actor(
+            client,
+            actor_id=actor_id,
+            bible_id=bible_id,
+            tag="BRANDON",
+            character_name="Brandon",
+            character_description=(
+                "A veteran freelance data courier: bald, rectangular glasses, a subtle "
+                "data-implant scar behind the right ear. Calm under pressure, always scanning."
+            ),
+            role="LEAD",
+            voice_profile_id=None,
+            wardrobe_label="Courier rig",
+            wardrobe_description=(
+                "Worn black tactical jacket with high collar over a graphite tech-weave shirt, "
+                "matte utility strap across the chest, dark cargo trousers — rain-slick "
+                "cyberpunk street courier."
+            ),
+        )
+        _bind_actor(
+            client,
+            actor_id=narrator_actor_id,
+            bible_id=bible_id,
+            tag="NARRATOR",
+            character_name="Narrator",
+            character_description="Brandon's interior noir voiceover. Never appears on screen.",
+            role="NARRATOR",
+            voice_profile_id=voice_profile_id,
+            wardrobe_label="No wardrobe (voice only)",
+            wardrobe_description="Voice-only narrator; no on-screen appearance.",
+        )
+
+        for set_name, set_tag, set_desc, lighting in [
+            (
+                "Neon Street Market",
+                "NEON_MARKET",
+                "Rain-slick cyberpunk street market: dense crowds, noodle stalls, steam vents, "
+                "towering holographic advertisements in kanji and hangul, tangled power lines.",
+                "Saturated neon signage (magenta/cyan) reflecting off wet asphalt; volumetric steam.",
+            ),
+            (
+                "Underground Data Den",
+                "DATA_DEN",
+                "Cramped hacker den beneath a noodle bar: racks of salvaged servers, CRT monitors, "
+                "cable bundles on every wall, a battered cyberdeck workstation.",
+                "Dim practicals — CRT green and amber glow, single hanging bulb, deep shadows.",
+            ),
+            (
+                "Megacity Rooftop",
+                "ROOFTOP_SKYLINE",
+                "Flat industrial rooftop high above an endless cyberpunk megacity skyline; "
+                "antenna clusters, vents, distant arcologies and searchlight drones.",
+                "Pre-dawn blue hour with neon haze below; first gray light on the horizon.",
+            ),
+        ]:
+            library_set = _assert_ok(client.post(
+                _api("/asset-library/sets"),
+                json={
+                    "name": set_name,
+                    "description": set_desc,
+                    "prompt_tags": [set_tag, "cyberpunk"],
+                    "lighting_notes": lighting,
+                },
+            ))
+            _assert_ok(client.post(
+                _api(f"/production-bibles/{bible_id}/set-bindings"),
+                json={
+                    "library_set_id": library_set["id"],
+                    "tag": set_tag,
+                    "production_name": set_name,
+                },
+            ))
+
+        cyberdeck = _assert_ok(client.post(
+            _api("/asset-library/props"),
+            json={
+                "name": "Cyberdeck",
+                "description": "A battered portable cyberdeck — matte black slab with worn keys and a coiled neural jack cable.",
+                "appearance_prompt": "Battered matte-black portable cyberdeck console, worn keycaps, coiled neural jack cable, scuffed decals.",
+                "prompt_tags": ["CYBERDECK", "cyberpunk"],
+            },
+        ))
+        _assert_ok(client.post(
+            _api(f"/production-bibles/{bible_id}/prop-bindings"),
+            json={
+                "library_prop_id": cyberdeck["id"],
+                "tag": "CYBERDECK",
+                "production_name": "Cyberdeck",
+            },
+        ))
+        _assert_ok(client.post(_api(f"/production-bibles/{bible_id}/finalize")))
+
+        screenplay = _seed_screenplay(client, production_id)
+        assert screenplay["text_model"] == TEXT_MODEL
+        _assert_ok(client.patch(_api(f"/productions/{production_id}/screenplay/status"), json={"status": "LOCKED"}))
+        created_scenes = _assert_ok(client.post(
+            _api(f"/productions/{production_id}/screenplay/generate-scenes?force=true"),
+        ))
+        assert len(created_scenes) >= SCENE_COUNT
+
+        completed_scenes = []
+        for scene in created_scenes[:SCENE_COUNT]:
+            scene_id = scene["scene_id"]
+            _assert_ok(client.patch(
+                _api(f"/scenes/{scene_id}/edit"),
+                json={
+                    "clip_duration": CLIP_DURATION_SECONDS,
+                    "target_shot_count": SHOTS_PER_SCENE,
+                    "text_model": TEXT_MODEL,
+                    "vision_model": VISION_MODEL,
+                    "image_model": IMAGE_MODEL,
+                    "video_model": VIDEO_MODEL,
+                    "audio_enabled": AUDIO_ENABLED,
+                    "production_bible_id": bible_id,
+                    "commit_message": "Configure cyberpunk E2E models and shot count",
+                },
+            ))
+            _assert_ok(client.post(
+                _api(f"/scenes/{scene_id}/regenerate"),
+                json={
+                    "scope": "all_phases",
+                    "text_model": TEXT_MODEL,
+                    "image_model": IMAGE_MODEL,
+                    "video_model": VIDEO_MODEL,
+                },
+                timeout=120,
+            ))
+            completed_scenes.append(_wait_for_scene(client, scene_id))
+
+        assert len(completed_scenes) == SCENE_COUNT
+        assert all(scene["shot_count"] >= SHOTS_PER_SCENE for scene in completed_scenes)
+
+        voice_script = _assert_ok(client.post(
+            _api(f"/productions/{production_id}/voice-script/generate"),
+            json={"text_model": TEXT_MODEL},
+            timeout=300,
+        ))["voice_script"]
+        _assert_ok(client.post(_api(f"/voice-scripts/{voice_script['id']}/resolve-bindings")))
+        voice_script = _assert_ok(client.post(
+            _api(f"/voice-scripts/{voice_script['id']}/generate-audio"),
+            timeout=600,
+        ))["voice_script"]
+        assert any(line["generation_status"] == "READY" for line in voice_script["lines"])
+        voice_script = _assert_ok(client.post(_api(f"/voice-scripts/{voice_script['id']}/mix")))["voice_script"]
+        assert any(artifact["status"] == "READY" for artifact in voice_script["mix_artifacts"])
+
+        sound_deck = _assert_ok(client.post(
+            _api(f"/productions/{production_id}/sound-deck/generate"),
+            json={"text_model": TEXT_MODEL},
+            timeout=300,
+        ))["sound_deck"]
+        assert len(sound_deck["cues"]) >= SCENE_COUNT
+
+        sound_deck = _assert_ok(client.post(
+            _api(f"/productions/{production_id}/sound-deck/generate-audio"),
+            timeout=900,
+        ))["sound_deck"]
+        ready_sound_cues = [cue for cue in sound_deck["cues"] if cue["generation_status"] == "READY"]
+        assert len(ready_sound_cues) >= SCENE_COUNT
+
+        sound_deck = _assert_ok(client.post(
+            _api(f"/productions/{production_id}/sound-deck/mix"),
+            timeout=600,
+        ))["sound_deck"]
+        ready_sfx_stems = [
+            artifact
+            for artifact in sound_deck["mix_artifacts"]
+            if artifact["artifact_type"] == "SCENE_SFX_STEM" and artifact["status"] == "READY"
+        ]
+        assert len(ready_sfx_stems) >= SCENE_COUNT
+
+        master = _assert_ok(client.post(_api(f"/productions/{production_id}/render-master"), timeout=900))
+        assert master["scene_count"] >= SCENE_COUNT
+
+        video_response = client.get(f"{API_BASE}{master['video_url']}", timeout=900)
+        assert video_response.status_code == 200
+        master_path = tmp_path / "cyberpunk_master.mp4"
+        master_path.write_bytes(video_response.content)
+        _assert_master_has_audio(master_path)
+
+        print(f"\nPRODUCTION_ID={production_id}")
+        print(f"MASTER_BYTES={len(video_response.content)}")

--- a/backend/tests/test_entity_extraction.py
+++ b/backend/tests/test_entity_extraction.py
@@ -1,0 +1,35 @@
+"""Tests for post-generation entity extraction wiring."""
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from vidpipe.services.entity_extraction import extract_and_register_new_entities
+
+
+@pytest.mark.asyncio
+async def test_entity_extraction_uses_injected_vision_adapter(monkeypatch):
+    captured = {}
+    adapter = SimpleNamespace(name="ollama-vision-adapter")
+
+    class FakeReversePromptService:
+        def __init__(self, vision_adapter=None):
+            captured["vision_adapter"] = vision_adapter
+
+    monkeypatch.setattr(
+        "vidpipe.services.entity_extraction.ReversePromptService",
+        FakeReversePromptService,
+    )
+
+    registered = await extract_and_register_new_entities(
+        session=SimpleNamespace(),
+        scene_id=uuid.uuid4(),
+        manifest_id=uuid.uuid4(),
+        shot_index=0,
+        new_entities=[],
+        vision_adapter=adapter,
+    )
+
+    assert registered == []
+    assert captured["vision_adapter"] is adapter

--- a/backend/tests/test_face_restore_service.py
+++ b/backend/tests/test_face_restore_service.py
@@ -1,0 +1,42 @@
+"""Tests for the GPU face-restore / upscale service.
+
+Always-on tests cover config defaults and graceful degradation (missing
+torch/spandrel/weights → service simply unavailable, never raises). The real
+GPU restore/upscale is exercised by the live e2e run, not unit tests (it needs
+a CUDA GPU + ~430MB of weights not present in CI).
+"""
+
+import pytest
+
+from vidpipe.config import FaceSwapConfig
+from vidpipe.services.face_restore_service import (
+    FaceRestoreService,
+    get_face_restore_service,
+)
+
+
+def test_restore_config_defaults():
+    c = FaceSwapConfig()
+    assert c.restore is False            # opt-in
+    assert c.upscale_keyframes is False  # opt-in
+    assert c.restore_weight == pytest.approx(0.9)   # identity-preserving default
+    assert c.upscale_scale == 4
+
+
+def test_degrades_gracefully_when_models_missing(monkeypatch, tmp_path):
+    """No weights (or no torch/spandrel) → unavailable, ops return None, no raise."""
+    from vidpipe.config import settings
+
+    # point at an empty dir so the weight files are absent
+    monkeypatch.setattr(settings.face_swap, "restore_model_dir", str(tmp_path), raising=False)
+    svc = FaceRestoreService()  # fresh instance, bypass singleton cache
+    # available() may be False due to missing weights and/or missing torch/spandrel
+    assert svc.available() is False
+    assert svc.has_restore() is False
+    assert svc.has_upscale() is False
+    assert svc.restore_primary_face(b"not-an-image") is None
+    assert svc.upscale(b"not-an-image", 4) is None
+
+
+def test_singleton_accessor():
+    assert get_face_restore_service() is get_face_restore_service()

--- a/backend/tests/test_face_swap_service.py
+++ b/backend/tests/test_face_swap_service.py
@@ -1,0 +1,121 @@
+"""Tests for the post-generation face-swap service (vidpipe.services.face_swap_service).
+
+The graceful-degrade path (inswapper weight absent) runs everywhere and is the
+safety net that keeps the pipeline working when the model isn't installed. The
+real-swap assertions are gated on the weight existing locally (it is gitignored
+and not present in CI) plus a sample face image supplied via env var — mirroring
+how the heavier QA tests opt in (see test_video_qa.py).
+
+    # Run the gated real-swap tests against a local model + face images:
+    VIDPIPE_FACESWAP_TEST_IMAGE=/path/to/source_face.png \
+    VIDPIPE_FACESWAP_TARGET_IMAGE=/path/to/other_face.png \
+    pytest backend/tests/test_face_swap_service.py -q
+"""
+
+import os
+
+import pytest
+
+from vidpipe.config import FaceSwapConfig
+from vidpipe.services.face_swap_service import (
+    FaceSwapService,
+    _inswapper_path,
+    get_face_swap_service,
+)
+
+# Cheap file-existence gate (does NOT load the ~800MB models at collection time).
+_HAVE_MODEL = os.path.exists(_inswapper_path())
+requires_model = pytest.mark.skipif(
+    not _HAVE_MODEL, reason="inswapper_128.onnx not installed locally."
+)
+
+
+# --- Always-on: config defaults + graceful degrade -------------------------
+def test_config_defaults_opt_in_off():
+    """Face-swap is opt-in; restoration deferred; det-score gate set."""
+    c = FaceSwapConfig()
+    assert c.enabled is False
+    assert c.restore is False
+    assert c.min_det_score == pytest.approx(0.50)
+
+
+def test_degrades_gracefully_when_model_missing(monkeypatch, tmp_path):
+    """No inswapper weight → service unavailable and swaps no-op (never raises)."""
+    missing = str(tmp_path / "nope" / "inswapper_128.onnx")
+    monkeypatch.setattr(
+        "vidpipe.services.face_swap_service._inswapper_path", lambda: missing
+    )
+    svc = FaceSwapService()  # fresh instance — bypass the module singleton cache
+    assert svc.available() is False
+    # Bad/empty inputs must not raise when the service is unavailable.
+    assert svc.swap_face_with_score(b"not-an-image", b"also-not") == (None, 0.0)
+    assert svc.swap_face(b"x", b"y") is None
+    assert svc.pick_clearest([b"x", b"y"]) is None
+
+
+def test_singleton_accessor_returns_same_instance():
+    assert get_face_swap_service() is get_face_swap_service()
+
+
+# --- Gated on the model actually being installed locally --------------------
+def _load_svc():
+    svc = get_face_swap_service()
+    if not svc.available():
+        pytest.skip("face-swap service failed to load despite weight present.")
+    return svc
+
+
+@requires_model
+def test_pick_clearest_prefers_detectable_face():
+    """A real face outranks a noise image (which has no detectable face)."""
+    cv2 = pytest.importorskip("cv2")
+    import numpy as np
+
+    sample = os.getenv("VIDPIPE_FACESWAP_TEST_IMAGE")
+    if not sample or not os.path.exists(sample):
+        pytest.skip("Set VIDPIPE_FACESWAP_TEST_IMAGE to a real face image.")
+    svc = _load_svc()
+
+    with open(sample, "rb") as f:
+        face_png = f.read()
+    rng = np.random.default_rng(0)
+    noise = rng.integers(0, 255, size=(256, 256, 3), dtype=np.uint8)
+    _, buf = cv2.imencode(".png", noise)
+    noise_png = buf.tobytes()
+
+    assert svc.pick_clearest([noise_png, face_png]) == face_png
+    assert svc.pick_clearest([noise_png]) is None
+
+
+@requires_model
+def test_swap_moves_identity_toward_source():
+    """Swapping source onto a target makes the result resemble the source.
+
+    With two distinct faces this is the POC assertion (0.17 -> 0.87): the
+    swapped frame's similarity to the source exceeds the original target's
+    similarity to the source. With a single image it degenerates to a self-swap
+    smoke test (high similarity, swap machinery works end-to-end).
+    """
+    from vidpipe.qa.vision import embedding_similarity
+
+    source = os.getenv("VIDPIPE_FACESWAP_TEST_IMAGE")
+    if not source or not os.path.exists(source):
+        pytest.skip("Set VIDPIPE_FACESWAP_TEST_IMAGE to a real face image.")
+    target = os.getenv("VIDPIPE_FACESWAP_TARGET_IMAGE") or source
+    svc = _load_svc()
+
+    with open(source, "rb") as f:
+        source_png = f.read()
+    with open(target, "rb") as f:
+        target_png = f.read()
+
+    swapped, sim = svc.swap_face_with_score(target_png, source_png)
+    assert swapped is not None, "expected a detectable face in the target"
+    assert sim >= 0.5, f"swapped face barely resembles source (sim={sim:.3f})"
+
+    if target != source:
+        before = embedding_similarity(source_png, target_png) or 0.0
+        assert sim > before, (
+            f"swap did not move identity toward source "
+            f"(before={before:.3f}, after={sim:.3f})"
+        )

--- a/backend/tests/test_model_catalog.py
+++ b/backend/tests/test_model_catalog.py
@@ -165,3 +165,57 @@ async def test_legacy_model_migration_updates_persisted_scene_and_settings(test_
         assert settings.default_text_model == "gemini-3.1-pro-preview"
         assert settings.default_video_model == "veo-3.1-generate-001"
         assert settings.default_vision_model == "gemini-3.1-pro-preview"
+
+
+# ---------------------------------------------------------------------------
+# Catalog consistency for ComfyUI video models
+# ---------------------------------------------------------------------------
+
+def test_every_video_model_has_durations_and_costs():
+    from vidpipe.services.model_catalog import (
+        VIDEO_MODEL_COST_AUDIO,
+        VIDEO_MODEL_COST_SILENT,
+        VIDEO_MODEL_DURATIONS,
+        VIDEO_MODELS,
+    )
+
+    for model_id in VIDEO_MODELS:
+        assert model_id in VIDEO_MODEL_DURATIONS, f"{model_id} missing durations"
+        assert VIDEO_MODEL_DURATIONS[model_id], f"{model_id} has empty durations"
+        assert model_id in VIDEO_MODEL_COST_SILENT, f"{model_id} missing silent cost"
+        assert model_id in VIDEO_MODEL_COST_AUDIO, f"{model_id} missing audio cost"
+
+
+def test_audio_capability_for_new_models():
+    # AUDIO_CAPABLE_VIDEO_MODELS is computed by set subtraction — new models
+    # are audio-capable unless excluded. Pin the intended membership.
+    from vidpipe.services.model_catalog import AUDIO_CAPABLE_VIDEO_MODELS
+
+    assert "wan-2.2-i2v" not in AUDIO_CAPABLE_VIDEO_MODELS
+    assert "wan-2.2-flf2v" not in AUDIO_CAPABLE_VIDEO_MODELS
+    assert "ltx-2.3-flf2v" in AUDIO_CAPABLE_VIDEO_MODELS
+    assert "seedance-2.0-flf2v" in AUDIO_CAPABLE_VIDEO_MODELS
+
+
+def test_comfyui_routing_matches_adapter_specs():
+    # Every model routed to ComfyUI must have an adapter spec, and all
+    # ComfyUI video models must be registered in the public catalog.
+    from vidpipe.pipeline.video_gen import COMFYUI_VIDEO_MODELS
+    from vidpipe.services.comfyui_adapter import COMFY_VIDEO_SPECS
+    from vidpipe.services.model_catalog import VIDEO_MODELS
+
+    assert set(COMFY_VIDEO_SPECS) == COMFYUI_VIDEO_MODELS
+    assert COMFYUI_VIDEO_MODELS <= VIDEO_MODELS
+
+
+def test_comfyui_image_models_registered():
+    from vidpipe.pipeline.keyframes import (
+        COMFYUI_IMAGE_MODELS,
+        COMFYUI_MULTIREF_IMAGE_MODELS,
+    )
+    from vidpipe.services.model_catalog import IMAGE_MODEL_COST, IMAGE_MODELS
+
+    assert COMFYUI_IMAGE_MODELS <= IMAGE_MODELS
+    assert COMFYUI_MULTIREF_IMAGE_MODELS <= COMFYUI_IMAGE_MODELS
+    for model_id in IMAGE_MODELS:
+        assert model_id in IMAGE_MODEL_COST, f"{model_id} missing image cost"

--- a/backend/tests/test_motion_escalation.py
+++ b/backend/tests/test_motion_escalation.py
@@ -1,0 +1,59 @@
+"""Tests for motion-prompt escalation (vidpipe.services.comfyui_adapter).
+
+When a generated LTX/ComfyUI clip measures near-static, the pipeline rewrites
+the motion prompt to force visible movement and resubmits. escalate_motion_prompt
+is the pure rewrite; these tests pin its behavior.
+"""
+
+from vidpipe.services.comfyui_adapter import escalate_motion_prompt
+
+# The exact frozen-clip prompt from production 89d98b1b scene 1 shot 0.
+FROZEN_PROMPT = (
+    "The camera slowly tracks backward in a smooth, steady motion, "
+    "maintaining a wide-to-medium framing on the subject as he walks forward "
+    "through the oncoming crowd."
+)
+
+FREEZE_WORDS = [
+    "slowly",
+    "smooth, steady",
+    "remains static",
+    "gently",
+    "subtle",
+    "motionless",
+]
+
+
+def test_prepends_high_motion_override():
+    out = escalate_motion_prompt(FROZEN_PROMPT)
+    assert out.startswith("HIGH MOTION:")
+
+
+def test_removes_freeze_words_from_original_text():
+    out = escalate_motion_prompt(FROZEN_PROMPT)
+    # Strip the override prefix; only inspect the rewritten original.
+    body = out.split("Avoid any static or frozen moment. ", 1)[1]
+    assert "slowly" not in body.lower()
+    assert "smooth, steady" not in body.lower()
+
+
+def test_substitutions_are_case_insensitive():
+    out = escalate_motion_prompt("The camera Remains Static. Subtle breathing.")
+    body = out.split("Avoid any static or frozen moment. ", 1)[1]
+    assert "remains static" not in body.lower()
+    assert "subtle" not in body.lower()
+    assert "moves dynamically" in body
+    assert "pronounced" in body
+
+
+def test_preserves_non_freeze_content():
+    out = escalate_motion_prompt(FROZEN_PROMPT)
+    assert "crowd" in out
+    assert "subject" in out
+
+
+def test_idempotent_on_already_dynamic_prompt():
+    dynamic = "The subject strides briskly through the market as the camera tracks."
+    out = escalate_motion_prompt(dynamic)
+    assert out.startswith("HIGH MOTION:")
+    assert "strides briskly" in out

--- a/backend/tests/test_nano_banana_refs.py
+++ b/backend/tests/test_nano_banana_refs.py
@@ -18,11 +18,14 @@ from vidpipe.db.models import (
     Base,
     CastBinding,
     CastLook,
+    DEFAULT_USER_ID,
     LibrarySet,
     LibrarySetRef,
     ProductionBible,
     SetBinding,
     Shot,
+    User,
+    UserSettings,
 )
 from vidpipe.pipeline.keyframes import (
     _GeneratedKeyframeAttempt,
@@ -42,6 +45,8 @@ from vidpipe.pipeline.keyframes import (
     _build_retry_reference_candidates,
     _select_best_effort_attempt,
     _verify_generated_keyframe,
+    _verify_keyframe_characters_with_vision,
+    _uses_comfyui_vision_primary,
 )
 from vidpipe.services.file_manager import FileManager
 from vidpipe.services.ref_prequalification import QualifiedRef
@@ -158,6 +163,102 @@ async def session_factory():
         yield factory
     finally:
         await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_vision_verifier_uses_user_settings_for_ollama_cloud(
+    session_factory,
+    monkeypatch,
+):
+    captured: dict[str, object] = {}
+    tiny_png = (
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
+        b"\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde"
+        b"\x00\x00\x00\x0cIDATx\x9cc\xf8\xff\xff?\x00\x05"
+        b"\xfe\x02\xfeA\xcf\xd0\xe5\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+
+    class FakeVisionAdapter:
+        async def analyze_image(self, *args, **kwargs):
+            del args, kwargs
+            return SimpleNamespace(
+                passed=True,
+                character_visible=True,
+                identity_match=True,
+                wardrobe_match=True,
+                identity_score=9.0,
+                wardrobe_score=9.0,
+                issues=[],
+            )
+
+    def fake_get_adapter(model_id, user_settings=None):
+        captured["model_id"] = model_id
+        captured["user_settings"] = user_settings
+        return FakeVisionAdapter()
+
+    def fake_crop_plan(_keyframe_bytes, _targets):
+        return _CharacterCropPlan(
+            selections={
+                "BRANDON_CROSS": _CharacterCropSelection(
+                    tag="BRANDON_CROSS",
+                    image_bytes=tiny_png,
+                    bbox=[0, 0, 10, 10],
+                    used_full_frame=False,
+                )
+            },
+            detected_face_count=1,
+            detected_person_count=1,
+            detected_object_count=1,
+        )
+
+    monkeypatch.setattr("vidpipe.pipeline.keyframes.get_adapter", fake_get_adapter)
+    monkeypatch.setattr(
+        "vidpipe.pipeline.keyframes._select_character_candidate_boxes",
+        fake_crop_plan,
+    )
+
+    async with session_factory() as session:
+        session.add(User(id=DEFAULT_USER_ID, name="default"))
+        session.add(
+            UserSettings(
+                user_id=DEFAULT_USER_ID,
+                ollama_use_cloud=True,
+                ollama_endpoint="https://ollama.com",
+                ollama_api_key="test-key",
+            )
+        )
+        await session.commit()
+
+        report = await _verify_keyframe_characters_with_vision(
+            session=session,
+            scene=SimpleNamespace(
+                vision_model="ollama/kimi-k2.5:cloud",
+                text_model="ollama/kimi-k2.5:cloud",
+            ),
+            shot=SimpleNamespace(shot_index=0),
+            shot_manifest_json={
+                "placements": [{"asset_tag": "BRANDON_CROSS", "position": "center"}]
+            },
+            keyframe_bytes=b"frame",
+            selected_candidates=[
+                _ReferenceCandidate(
+                    tag="BRANDON_CROSS",
+                    image_url="face",
+                    image_bytes=tiny_png,
+                    asset_type="CHARACTER",
+                    source="binding",
+                    identity_type="HUMAN",
+                    reference_kind="face",
+                )
+            ],
+            identity_types_by_tag={"BRANDON_CROSS": "HUMAN"},
+        )
+
+    assert report.passed is True
+    assert captured["model_id"] == "ollama/kimi-k2.5:cloud"
+    assert captured["user_settings"] is not None
+    assert captured["user_settings"].ollama_use_cloud is True
+    assert captured["user_settings"].ollama_api_key == "test-key"
 
 
 @pytest.mark.asyncio
@@ -804,6 +905,7 @@ async def test_crowded_human_verification_uses_vision_as_authority(monkeypatch):
     )
 
     report = await _verify_generated_keyframe(
+        session=SimpleNamespace(),
         scene=SimpleNamespace(vision_model="gemini", text_model="gemini"),
         shot=SimpleNamespace(shot_index=1),
         position="end",
@@ -886,6 +988,7 @@ async def test_single_human_verification_stays_strict(monkeypatch):
     )
 
     report = await _verify_generated_keyframe(
+        session=SimpleNamespace(),
         scene=SimpleNamespace(vision_model="gemini", text_model="gemini"),
         shot=SimpleNamespace(shot_index=1),
         position="end",
@@ -910,6 +1013,179 @@ async def test_single_human_verification_stays_strict(monkeypatch):
     assert report.passed is False
     assert report.verification_mode == "strict_face_and_vision"
     assert report.face_results[0].advisory is False
+
+
+@pytest.mark.asyncio
+async def test_single_human_near_threshold_face_can_use_strong_vision(monkeypatch):
+    async def fake_vision_report(**kwargs):
+        del kwargs
+        return _VisionVerificationReport(
+            passed=True,
+            detail="vision ok",
+            results=[
+                _CharacterVisionVerificationResult(
+                    tag="BRANDON_CROSS",
+                    passed=True,
+                    character_visible=True,
+                    identity_match=True,
+                    wardrobe_match=True,
+                    identity_score=8.5,
+                    wardrobe_score=8.0,
+                    issues=[],
+                    used_full_frame=False,
+                )
+            ],
+        )
+
+    def fake_crop_plan(_keyframe_bytes, _targets):
+        return _CharacterCropPlan(
+            selections={
+                "BRANDON_CROSS": _CharacterCropSelection(
+                    tag="BRANDON_CROSS",
+                    image_bytes=b"crop",
+                    bbox=[0, 0, 10, 10],
+                    used_full_frame=False,
+                )
+            },
+            detected_face_count=1,
+            detected_person_count=1,
+            detected_object_count=1,
+        )
+
+    async def fake_verify_target_face(_crop_bytes, _ref_embeddings, threshold=None):
+        del threshold
+        return False, 0.383, "best_sim=0.383 threshold=0.450 refs_checked=1"
+
+    monkeypatch.setattr(
+        "vidpipe.pipeline.keyframes._verify_keyframe_characters_with_vision",
+        fake_vision_report,
+    )
+    monkeypatch.setattr(
+        "vidpipe.pipeline.keyframes._select_character_candidate_boxes",
+        fake_crop_plan,
+    )
+    monkeypatch.setattr(
+        "vidpipe.pipeline.keyframes._verify_target_face",
+        fake_verify_target_face,
+    )
+
+    report = await _verify_generated_keyframe(
+        session=SimpleNamespace(),
+        scene=SimpleNamespace(vision_model="gemini", text_model="gemini"),
+        shot=SimpleNamespace(shot_index=1),
+        position="start",
+        keyframe_bytes=b"frame",
+        shot_manifest_json={"placements": [{"asset_tag": "BRANDON_CROSS", "position": "left"}]},
+        selected_candidates=[
+            _ReferenceCandidate(
+                tag="BRANDON_CROSS",
+                image_url="face",
+                image_bytes=b"face",
+                asset_type="CHARACTER",
+                source="binding",
+                identity_type="HUMAN",
+                reference_kind="face",
+            )
+        ],
+        identity_types_by_tag={"BRANDON_CROSS": "HUMAN"},
+        placed_char_assets=[],
+        prequalified_ref_embeddings_by_tag={"BRANDON_CROSS": [np.ones(4, dtype=np.float32)]},
+    )
+
+    assert report.passed is True
+    assert report.verification_mode == "strict_face_and_vision"
+    assert report.face_results[0].advisory is False
+    assert "vision_corroborated_near_threshold_face=@BRANDON_CROSS" in report.detail
+
+
+@pytest.mark.asyncio
+async def test_comfyui_multiref_single_human_uses_vision_primary(monkeypatch):
+    async def fake_vision_report(**kwargs):
+        del kwargs
+        return _VisionVerificationReport(
+            passed=True,
+            detail="vision ok",
+            results=[
+                _CharacterVisionVerificationResult(
+                    tag="BRANDON_CROSS",
+                    passed=True,
+                    character_visible=True,
+                    identity_match=True,
+                    wardrobe_match=True,
+                    identity_score=8.5,
+                    wardrobe_score=8.0,
+                    issues=[],
+                    used_full_frame=False,
+                )
+            ],
+        )
+
+    def fail_crop_plan(_keyframe_bytes, _targets):
+        raise AssertionError("ComfyUI multi-ref verification should use full-frame crops")
+
+    async def fail_verify_target_face(_crop_bytes, _ref_embeddings, threshold=None):
+        del threshold
+        raise AssertionError("ComfyUI multi-ref verification should not load face embeddings")
+
+    monkeypatch.setattr(
+        "vidpipe.pipeline.keyframes._verify_keyframe_characters_with_vision",
+        fake_vision_report,
+    )
+    monkeypatch.setattr(
+        "vidpipe.pipeline.keyframes._select_character_candidate_boxes",
+        fail_crop_plan,
+    )
+    monkeypatch.setattr(
+        "vidpipe.pipeline.keyframes._verify_target_face",
+        fail_verify_target_face,
+    )
+
+    report = await _verify_generated_keyframe(
+        session=SimpleNamespace(),
+        scene=SimpleNamespace(
+            image_model="qwen-image-edit-2509",
+            vision_model="ollama/kimi-k2.5:cloud",
+            text_model="ollama/kimi-k2.5:cloud",
+        ),
+        shot=SimpleNamespace(shot_index=1),
+        position="start",
+        keyframe_bytes=b"frame",
+        shot_manifest_json={"placements": [{"asset_tag": "BRANDON_CROSS", "position": "left"}]},
+        selected_candidates=[
+            _ReferenceCandidate(
+                tag="BRANDON_CROSS",
+                image_url="face",
+                image_bytes=b"face",
+                asset_type="CHARACTER",
+                source="binding",
+                identity_type="HUMAN",
+                reference_kind="face",
+            )
+        ],
+        identity_types_by_tag={"BRANDON_CROSS": "HUMAN"},
+        placed_char_assets=[],
+        prequalified_ref_embeddings_by_tag={"BRANDON_CROSS": [np.ones(4, dtype=np.float32)]},
+    )
+
+    assert report.passed is True
+    assert report.verification_mode == "vision_primary_face_advisory"
+    assert report.face_results[0].passed is False
+    assert report.face_results[0].advisory is True
+
+
+def test_comfyui_vision_primary_policy_covers_multiref_models():
+    assert _uses_comfyui_vision_primary(
+        SimpleNamespace(image_model="qwen-image-edit-2509")
+    )
+    assert _uses_comfyui_vision_primary(
+        SimpleNamespace(image_model="flux-2-klein")
+    )
+    assert not _uses_comfyui_vision_primary(
+        SimpleNamespace(image_model="qwen-fast")
+    )
+    assert not _uses_comfyui_vision_primary(
+        SimpleNamespace(image_model="gemini-2.5-flash-image")
+    )
 
 
 def test_best_effort_selection_prefers_visible_identity_match():

--- a/backend/tests/test_orphan_recovery.py
+++ b/backend/tests/test_orphan_recovery.py
@@ -1,0 +1,30 @@
+"""Tests for restart-orphan recovery: resumability of in-flight statuses.
+
+A server restart mid-pipeline (e.g. container rebuild) used to strand scenes
+in "generating_video" — not resumable, not stoppable, invisible to recovery.
+"""
+
+from vidpipe.orchestrator.recovery import IN_FLIGHT_STATUSES
+from vidpipe.orchestrator.state import RESUMABLE_STATES, can_resume, get_resume_step
+
+
+def test_generating_video_is_resumable():
+    assert can_resume("generating_video")
+
+
+def test_generating_video_resumes_at_video_gen():
+    completed = {"has_storyboard": True, "has_keyframes": True, "has_clips": False}
+    assert get_resume_step("generating_video", completed) == "video_gen"
+
+
+def test_all_in_flight_statuses_are_resumable():
+    """Every status startup recovery targets must be accepted by resume."""
+    for status in IN_FLIGHT_STATUSES:
+        assert status in RESUMABLE_STATES, (
+            f"startup recovery would resume '{status}' but it is not resumable"
+        )
+
+
+def test_terminal_statuses_are_not_recovered():
+    for status in ("complete", "failed", "stopped", "draft", "staged"):
+        assert status not in IN_FLIGHT_STATUSES

--- a/backend/tests/test_video_qa.py
+++ b/backend/tests/test_video_qa.py
@@ -1,0 +1,45 @@
+"""Adversarial video-QA gate (opt-in).
+
+Audits a finished production and FAILS if any CRITICAL quality criterion is
+violated (off-model character identity, audio garble/corruption, etc.).
+
+Run against a live API + a finished production:
+
+    VIDPIPE_QA_PRODUCTION_ID=<id> \
+    VIDPIPE_QA_API_BASE=http://localhost:8000 \
+    pytest backend/tests/test_video_qa.py -q -s
+
+Skips by default so the normal suite stays offline/fast.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+PID = os.getenv("VIDPIPE_QA_PRODUCTION_ID")
+
+pytestmark = pytest.mark.skipif(
+    not PID, reason="Set VIDPIPE_QA_PRODUCTION_ID to audit a finished production.")
+
+
+@pytest.mark.asyncio
+async def test_production_meets_quality_bar(tmp_path):
+    from vidpipe.qa.audit import run_audit
+
+    api = os.getenv("VIDPIPE_QA_API_BASE", "http://localhost:8000")
+    out = Path(os.getenv("VIDPIPE_QA_OUT", str(tmp_path)))
+    verdict = await run_audit(
+        api, PID, out,
+        sample_every=int(os.getenv("VIDPIPE_QA_SAMPLE_EVERY", "10")),
+        do_embed=os.getenv("VIDPIPE_QA_NO_EMBED") != "1",
+        do_vision=os.getenv("VIDPIPE_QA_NO_VISION") != "1",
+    )
+    crit = verdict.critical
+    assert not crit, (
+        f"{len(crit)} CRITICAL QA finding(s):\n"
+        + "\n".join(f"  [{f.code}] {f.where} — {f.message}" for f in crit)
+        + f"\nFull report: {out}/report.md"
+    )

--- a/backend/vidpipe/api/app.py
+++ b/backend/vidpipe/api/app.py
@@ -1,5 +1,6 @@
 """FastAPI application setup with lifespan and exception handlers."""
 
+import asyncio
 from contextlib import asynccontextmanager
 import logging
 from pathlib import Path
@@ -26,6 +27,7 @@ from vidpipe.api.asset_library import asset_library_router
 from vidpipe.api.editor_images import editor_images_router
 from vidpipe.api.production_master import production_master_router
 from vidpipe.api.sound_deck import sound_deck_router
+from vidpipe.api.upscale_routes import upscale_router
 
 # Configure root logger so application logs (pipeline stages, S3, etc.) reach stdout
 logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s: %(message)s")
@@ -50,12 +52,24 @@ async def lifespan(app: FastAPI):
     await init_database()
     await load_vertex_credentials_from_db()
     await load_comfyui_credentials_from_db()
+
+    # Resume scenes orphaned in in-flight statuses by a previous restart
+    # (e.g. container rebuild mid-pipeline). Runs in the background so
+    # startup is not blocked.
+    recovery_task = None
+    from vidpipe.config import settings
+    if settings.pipeline.auto_resume_on_startup:
+        from vidpipe.orchestrator.recovery import recover_orphaned_scenes
+        recovery_task = asyncio.create_task(recover_orphaned_scenes())
+
     logger.info("API startup complete")
 
     yield
 
     # Shutdown
     logger.info("Shutting down Video Pipeline API...")
+    if recovery_task is not None and not recovery_task.done():
+        recovery_task.cancel()
     await close_comfyui_client()
     await shutdown()
     logger.info("API shutdown complete")
@@ -91,6 +105,7 @@ app.include_router(asset_library_router)
 app.include_router(editor_images_router)
 app.include_router(production_master_router)
 app.include_router(sound_deck_router)
+app.include_router(upscale_router)
 
 # Serve frontend static files in production (after API routes take priority)
 _frontend_dist = Path(__file__).resolve().parent.parent.parent.parent / "frontend" / "dist"

--- a/backend/vidpipe/api/routes.py
+++ b/backend/vidpipe/api/routes.py
@@ -5080,6 +5080,7 @@ async def _regenerate_keyframe(session, scene, shot, position, file_mgr, prompt_
     from vidpipe.pipeline.keyframes import (
         _generate_image_from_text, _generate_image_conditioned,
         COMFYUI_IMAGE_MODELS, _generate_image_comfyui, _generate_image_comfyui_flux,
+        _generate_image_comfyui_qwen_edit_2509, _generate_image_comfyui_flux2_klein,
     )
     is_comfyui = image_model in COMFYUI_IMAGE_MODELS
     comfy_client = None
@@ -5090,6 +5091,48 @@ async def _regenerate_keyframe(session, scene, shot, position, file_mgr, prompt_
     else:
         from vidpipe.services.vertex_client import get_vertex_client, location_for_model
         image_client = get_vertex_client(location=location_for_model(image_model))
+
+    async def _generate_multiref_comfyui(
+        prompt: str, *, conditioning_bytes: bytes | None, seed: int,
+    ) -> bytes | None:
+        """Dispatch generation for multi-ref ComfyUI image models.
+
+        Returns None when image_model is not one of them, so callers can fall
+        through to the legacy branches. With conditioning_bytes (prev/start
+        frame), it occupies the first input slot and identity refs fill the
+        rest; without it, refs alone drive generation at the scene aspect.
+        """
+        if image_model == "qwen-image-edit-2509":
+            if conditioning_bytes is not None:
+                return await _generate_image_comfyui_qwen_edit_2509(
+                    comfy_client, prompt, seed=seed,
+                    image_bytes_list=[conditioning_bytes] + ref_image_bytes_list[:2],
+                )
+            from vidpipe.services.comfyui_client import _QWEN_RESOLUTIONS
+            qw, qh = _QWEN_RESOLUTIONS.get(scene.aspect_ratio, (1328, 1328))
+            if ref_image_bytes_list:
+                return await _generate_image_comfyui_qwen_edit_2509(
+                    comfy_client, prompt, seed=seed,
+                    image_bytes_list=ref_image_bytes_list[:3],
+                    output_width=qw, output_height=qh,
+                )
+            # Edit model without any input image: fall back to qwen txt2img
+            return await _generate_image_comfyui(
+                comfy_client, prompt, seed=seed, width=qw, height=qh,
+            )
+        if image_model == "flux-2-klein":
+            from vidpipe.services.comfyui_client import _FLUX2_RESOLUTIONS
+            f2w, f2h = _FLUX2_RESOLUTIONS.get(scene.aspect_ratio, (1024, 1024))
+            refs = (
+                [conditioning_bytes] + ref_image_bytes_list[:3]
+                if conditioning_bytes is not None
+                else ref_image_bytes_list[:4]
+            )
+            return await _generate_image_comfyui_flux2_klein(
+                comfy_client, prompt, seed=seed, width=f2w, height=f2h,
+                reference_image_bytes_list=refs or None,
+            )
+        return None
 
     # Extract edited field values (user edits take priority over stale rewrites)
     edited_start = (shot_edits or {}).get("start_frame_prompt")
@@ -5110,7 +5153,11 @@ async def _regenerate_keyframe(session, scene, shot, position, file_mgr, prompt_
         if shot.shot_index == 0:
             # Shot 0: text-to-image with style/character enrichment
             enriched_prompt = f"{style_prefix}{character_prefix}{base_prompt}" if not prompt_override else base_prompt
-            if is_comfyui and image_model.startswith("flux-"):
+            if (mr := await _generate_multiref_comfyui(
+                enriched_prompt, conditioning_bytes=None, seed=scene.seed,
+            )) is not None:
+                image_bytes = mr
+            elif is_comfyui and image_model.startswith("flux-"):
                 from vidpipe.services.comfyui_client import _FLUX_RESOLUTIONS
                 fw, fh = _FLUX_RESOLUTIONS.get(scene.aspect_ratio, (1024, 1024))
                 image_bytes = await _generate_image_comfyui_flux(
@@ -5167,7 +5214,11 @@ async def _regenerate_keyframe(session, scene, shot, position, file_mgr, prompt_
                         f"- Same {style_label} rendering style\n"
                         f"{character_prefix}"
                     )
-                    if is_comfyui and image_model.startswith("flux-"):
+                    if (mr := await _generate_multiref_comfyui(
+                        conditioning_prompt, conditioning_bytes=prev_end_bytes, seed=scene.seed,
+                    )) is not None:
+                        image_bytes = mr
+                    elif is_comfyui and image_model.startswith("flux-"):
                         from vidpipe.services.comfyui_client import _FLUX_RESOLUTIONS as _FR2
                         fw2, fh2 = _FR2.get(scene.aspect_ratio, (1024, 1024))
                         image_bytes = await _generate_image_comfyui_flux(
@@ -5188,7 +5239,11 @@ async def _regenerate_keyframe(session, scene, shot, position, file_mgr, prompt_
             else:
                 # Fallback: no previous end keyframe available, use text-to-image
                 enriched_prompt = f"{style_prefix}{character_prefix}{base_prompt}" if not prompt_override else base_prompt
-                if is_comfyui and image_model.startswith("flux-"):
+                if (mr := await _generate_multiref_comfyui(
+                    enriched_prompt, conditioning_bytes=None, seed=scene.seed,
+                )) is not None:
+                    image_bytes = mr
+                elif is_comfyui and image_model.startswith("flux-"):
                     from vidpipe.services.comfyui_client import _FLUX_RESOLUTIONS as _FR3
                     fw3, fh3 = _FR3.get(scene.aspect_ratio, (1024, 1024))
                     image_bytes = await _generate_image_comfyui_flux(
@@ -5244,7 +5299,12 @@ async def _regenerate_keyframe(session, scene, shot, position, file_mgr, prompt_
                 f"{character_prefix}"
             )
 
-        if is_comfyui and image_model.startswith("flux-"):
+        if (mr := await _generate_multiref_comfyui(
+            conditioning_prompt, conditioning_bytes=conditioning_bytes,
+            seed=scene.seed + shot.shot_index + 1000,
+        )) is not None:
+            image_bytes = mr
+        elif is_comfyui and image_model.startswith("flux-"):
             from vidpipe.services.comfyui_client import _FLUX_RESOLUTIONS as _FR4
             fw4, fh4 = _FR4.get(scene.aspect_ratio, (1024, 1024))
             image_bytes = await _generate_image_comfyui_flux(

--- a/backend/vidpipe/api/routes.py
+++ b/backend/vidpipe/api/routes.py
@@ -5440,13 +5440,19 @@ async def _regenerate_clip(session, scene, shot, file_mgr, prompt_override=None,
             seed=scene.seed or 0,
             shot_index=shot.shot_index,
             video_model=video_model,
+            duration_seconds=scene.target_clip_duration or 5,
+            audio_enabled=bool(scene.audio_enabled),
         )
 
         # Poll ComfyUI
         for _ in range(max_polls):
             status, error_msg = await adapter.poll(operation_id)
             if status == "completed":
-                video_bytes, _duration = await adapter.download(operation_id)
+                video_bytes, _duration = await adapter.download(
+                    operation_id,
+                    video_model=video_model,
+                    duration_seconds=scene.target_clip_duration or 5,
+                )
                 break
             elif status == "failed":
                 raise RuntimeError(f"ComfyUI job failed: {error_msg}")

--- a/backend/vidpipe/api/routes.py
+++ b/backend/vidpipe/api/routes.py
@@ -1252,7 +1252,12 @@ async def get_scene_detail(scene_id: uuid.UUID):
                             name=asset.name,
                             asset_type=asset.asset_type,
                             thumbnail_url=asset.thumbnail_url,
-                            reference_image_url=asset.reference_image_url,
+                            # Serve via the asset image endpoint — the raw
+                            # column value is a storage key, not a URL.
+                            reference_image_url=(
+                                f"/api/assets/{asset.id}/image"
+                                if asset.reference_image_url else None
+                            ),
                             quality_score=asset.quality_score,
                             is_face_crop=asset.is_face_crop,
                         ))

--- a/backend/vidpipe/api/routes.py
+++ b/backend/vidpipe/api/routes.py
@@ -1507,7 +1507,10 @@ async def stop_scene(scene_id: uuid.UUID):
 
     Returns 409 if scene is already in a terminal state (complete/failed/stopped).
     """
-    ACTIVE_STATUSES = {"pending", "storyboarding", "keyframing", "video_gen", "stitching"}
+    ACTIVE_STATUSES = {
+        "pending", "storyboarding", "keyframing",
+        "video_gen", "generating_video", "stitching",
+    }
 
     async with async_session() as session:
         result = await session.execute(
@@ -5030,6 +5033,12 @@ async def _regenerate_keyframe(session, scene, shot, position, file_mgr, prompt_
     if image_model.startswith("imagen-"):
         image_model = app_settings.models.image_gen
 
+    # scene.seed may be None (scenes created via screenplay→generate-scenes never
+    # set it). Passing None as a ComfyUI seed fails: FLUX RandomNoise rejects a
+    # null noise_seed (HTTP 400), and the offset paths raise "NoneType + int".
+    # Match the main pipeline (int(scene.seed or 0)) so regeneration works.
+    regen_seed = int(scene.seed or 0)
+
     # Build character bible prefix from storyboard data
     character_prefix = ""
     if scene.storyboard_raw and "characters" in scene.storyboard_raw:
@@ -5159,22 +5168,22 @@ async def _regenerate_keyframe(session, scene, shot, position, file_mgr, prompt_
             # Shot 0: text-to-image with style/character enrichment
             enriched_prompt = f"{style_prefix}{character_prefix}{base_prompt}" if not prompt_override else base_prompt
             if (mr := await _generate_multiref_comfyui(
-                enriched_prompt, conditioning_bytes=None, seed=scene.seed,
+                enriched_prompt, conditioning_bytes=None, seed=regen_seed,
             )) is not None:
                 image_bytes = mr
             elif is_comfyui and image_model.startswith("flux-"):
                 from vidpipe.services.comfyui_client import _FLUX_RESOLUTIONS
                 fw, fh = _FLUX_RESOLUTIONS.get(scene.aspect_ratio, (1024, 1024))
                 image_bytes = await _generate_image_comfyui_flux(
-                    comfy_client, enriched_prompt, seed=scene.seed,
+                    comfy_client, enriched_prompt, seed=regen_seed,
                     width=fw, height=fh,
                 )
             elif is_comfyui:
-                image_bytes = await _generate_image_comfyui(comfy_client, enriched_prompt, seed=scene.seed)
+                image_bytes = await _generate_image_comfyui(comfy_client, enriched_prompt, seed=regen_seed)
             else:
                 image_bytes = await _generate_image_from_text(
                     image_client, enriched_prompt, scene.aspect_ratio, image_model,
-                    seed=scene.seed,
+                    seed=regen_seed,
                     reference_images=ref_image_bytes_list or None,
                 )
         else:
@@ -5220,18 +5229,18 @@ async def _regenerate_keyframe(session, scene, shot, position, file_mgr, prompt_
                         f"{character_prefix}"
                     )
                     if (mr := await _generate_multiref_comfyui(
-                        conditioning_prompt, conditioning_bytes=prev_end_bytes, seed=scene.seed,
+                        conditioning_prompt, conditioning_bytes=prev_end_bytes, seed=regen_seed,
                     )) is not None:
                         image_bytes = mr
                     elif is_comfyui and image_model.startswith("flux-"):
                         from vidpipe.services.comfyui_client import _FLUX_RESOLUTIONS as _FR2
                         fw2, fh2 = _FR2.get(scene.aspect_ratio, (1024, 1024))
                         image_bytes = await _generate_image_comfyui_flux(
-                            comfy_client, conditioning_prompt, seed=scene.seed,
+                            comfy_client, conditioning_prompt, seed=regen_seed,
                             width=fw2, height=fh2,
                         )
                     elif is_comfyui:
-                        image_bytes = await _generate_image_comfyui(comfy_client, conditioning_prompt, seed=scene.seed)
+                        image_bytes = await _generate_image_comfyui(comfy_client, conditioning_prompt, seed=regen_seed)
                     else:
                         image_bytes = await _generate_image_conditioned(
                             image_client, prev_end_bytes, conditioning_prompt,
@@ -5245,22 +5254,22 @@ async def _regenerate_keyframe(session, scene, shot, position, file_mgr, prompt_
                 # Fallback: no previous end keyframe available, use text-to-image
                 enriched_prompt = f"{style_prefix}{character_prefix}{base_prompt}" if not prompt_override else base_prompt
                 if (mr := await _generate_multiref_comfyui(
-                    enriched_prompt, conditioning_bytes=None, seed=scene.seed,
+                    enriched_prompt, conditioning_bytes=None, seed=regen_seed,
                 )) is not None:
                     image_bytes = mr
                 elif is_comfyui and image_model.startswith("flux-"):
                     from vidpipe.services.comfyui_client import _FLUX_RESOLUTIONS as _FR3
                     fw3, fh3 = _FR3.get(scene.aspect_ratio, (1024, 1024))
                     image_bytes = await _generate_image_comfyui_flux(
-                        comfy_client, enriched_prompt, seed=scene.seed,
+                        comfy_client, enriched_prompt, seed=regen_seed,
                         width=fw3, height=fh3,
                     )
                 elif is_comfyui:
-                    image_bytes = await _generate_image_comfyui(comfy_client, enriched_prompt, seed=scene.seed)
+                    image_bytes = await _generate_image_comfyui(comfy_client, enriched_prompt, seed=regen_seed)
                 else:
                     image_bytes = await _generate_image_from_text(
                         image_client, enriched_prompt, scene.aspect_ratio, image_model,
-                        seed=scene.seed,
+                        seed=regen_seed,
                         reference_images=ref_image_bytes_list or None,
                     )
 
@@ -5306,7 +5315,7 @@ async def _regenerate_keyframe(session, scene, shot, position, file_mgr, prompt_
 
         if (mr := await _generate_multiref_comfyui(
             conditioning_prompt, conditioning_bytes=conditioning_bytes,
-            seed=scene.seed + shot.shot_index + 1000,
+            seed=regen_seed + shot.shot_index + 1000,
         )) is not None:
             image_bytes = mr
         elif is_comfyui and image_model.startswith("flux-"):
@@ -5314,13 +5323,13 @@ async def _regenerate_keyframe(session, scene, shot, position, file_mgr, prompt_
             fw4, fh4 = _FR4.get(scene.aspect_ratio, (1024, 1024))
             image_bytes = await _generate_image_comfyui_flux(
                 comfy_client, conditioning_prompt,
-                seed=scene.seed + shot.shot_index + 1000,
+                seed=regen_seed + shot.shot_index + 1000,
                 width=fw4, height=fh4,
             )
         elif is_comfyui:
             image_bytes = await _generate_image_comfyui(
                 comfy_client, conditioning_prompt,
-                seed=scene.seed + shot.shot_index + 1000,
+                seed=regen_seed + shot.shot_index + 1000,
             )
         else:
             image_bytes = await _generate_image_conditioned(
@@ -5436,34 +5445,84 @@ async def _regenerate_clip(session, scene, shot, file_mgr, prompt_override=None,
             from vidpipe.pipeline.video_gen import _load_char_ref_images
             char_ref_bytes = await _load_char_ref_images(session, scene)
 
-        operation_id = await adapter.submit(
-            video_prompt=video_prompt,
-            start_frame_bytes=start_bytes,
-            end_frame_bytes=end_bytes if end_kf else None,
-            char_ref_bytes=char_ref_bytes,
-            aspect_ratio=scene.aspect_ratio,
-            seed=scene.seed or 0,
-            shot_index=shot.shot_index,
-            video_model=video_model,
-            duration_seconds=scene.target_clip_duration or 5,
-            audio_enabled=bool(scene.audio_enabled),
-        )
+        async def _submit_comfy(attempt: int) -> str:
+            # ``attempt`` perturbs the seed so a corrupted-clip retry cannot
+            # hit ComfyUI's node cache and receive the same corrupted encode.
+            return await adapter.submit(
+                video_prompt=video_prompt,
+                start_frame_bytes=start_bytes,
+                end_frame_bytes=end_bytes if end_kf else None,
+                char_ref_bytes=char_ref_bytes,
+                aspect_ratio=scene.aspect_ratio,
+                seed=(scene.seed or 0) + attempt * 1000003,
+                shot_index=shot.shot_index,
+                video_model=video_model,
+                duration_seconds=scene.target_clip_duration or 5,
+                audio_enabled=bool(scene.audio_enabled),
+            )
 
-        # Poll ComfyUI
-        for _ in range(max_polls):
-            status, error_msg = await adapter.poll(operation_id)
-            if status == "completed":
-                video_bytes, _duration = await adapter.download(
-                    operation_id,
-                    video_model=video_model,
-                    duration_seconds=scene.target_clip_duration or 5,
-                )
+        operation_id = await _submit_comfy(0)
+
+        corrupt_retry_max = (
+            app_settings.pipeline.clip_corrupt_retry_max
+            if app_settings.pipeline.clip_validation_enabled
+            else 0
+        )
+        import time as _time
+
+        for corruption_attempt in range(corrupt_retry_max + 1):
+            # Poll ComfyUI. Queue time (Comfy Cloud "queued_limited" under
+            # account concurrency limits) does not consume the poll budget.
+            polls_used = 0
+            queue_deadline = _time.monotonic() + app_settings.pipeline.comfy_queue_timeout
+            while True:
+                status, error_msg = await adapter.poll(operation_id)
+                if status == "completed":
+                    video_bytes, _duration = await adapter.download(
+                        operation_id,
+                        video_model=video_model,
+                        duration_seconds=scene.target_clip_duration or 5,
+                    )
+                    break
+                elif status == "failed":
+                    raise RuntimeError(f"ComfyUI job failed: {error_msg}")
+                elif status == "queued":
+                    if _time.monotonic() > queue_deadline:
+                        raise TimeoutError(
+                            f"ComfyUI job stayed queued too long for shot {shot.shot_index}"
+                        )
+                else:
+                    polls_used += 1
+                    if polls_used >= max_polls:
+                        raise TimeoutError(f"ComfyUI timed out for shot {shot.shot_index}")
+                await asyncio.sleep(poll_interval)
+
+            # Degenerate-clip gate (ComfyUI Cloud can return corrupted MP4s
+            # on jobs that report success)
+            if not app_settings.pipeline.clip_validation_enabled:
                 break
-            elif status == "failed":
-                raise RuntimeError(f"ComfyUI job failed: {error_msg}")
-            await asyncio.sleep(poll_interval)
-        else:
-            raise TimeoutError(f"ComfyUI timed out for shot {shot.shot_index}")
+            from vidpipe.services.clip_validation import validate_clip_integrity
+
+            validation = await asyncio.to_thread(
+                validate_clip_integrity,
+                video_bytes,
+                start_frame_bytes=start_bytes,
+                end_frame_bytes=end_bytes if end_kf else None,
+            )
+            if validation.ok:
+                break
+            logger.warning(
+                "Shot %d: regenerated clip failed integrity check (%s) — "
+                "attempt %d of %d",
+                shot.shot_index, validation.detail,
+                corruption_attempt + 1, corrupt_retry_max + 1,
+            )
+            if corruption_attempt >= corrupt_retry_max:
+                raise RuntimeError(
+                    f"Corrupted video from ComfyUI after "
+                    f"{corruption_attempt + 1} attempt(s): {validation.detail}"
+                )
+            operation_id = await _submit_comfy(corruption_attempt + 1)
     else:
         # ---- Veo / Vertex path ----
         from vidpipe.pipeline.video_gen import _submit_video_job

--- a/backend/vidpipe/api/upscale_routes.py
+++ b/backend/vidpipe/api/upscale_routes.py
@@ -55,6 +55,9 @@ def _process_video(src_path: str, out_path: str, scale: int) -> int:
                 up = cv2.resize(frame, None, fx=scale, fy=scale, interpolation=cv2.INTER_LANCZOS4)
             if proc is None:
                 h, w = up.shape[:2]
+                # Memory-safe encode: the default lookahead holds dozens of raw
+                # ~43MB 5K frames in RAM and OOM-killed ffmpeg (broken pipe).
+                # veryfast + a small rc-lookahead caps that buffer.
                 proc = subprocess.Popen(
                     [
                         "ffmpeg", "-y",
@@ -62,13 +65,18 @@ def _process_video(src_path: str, out_path: str, scale: int) -> int:
                         "-s", f"{w}x{h}", "-r", str(fps), "-i", "pipe:0",
                         "-i", src_path,
                         "-map", "0:v:0", "-map", "1:a:0?",
-                        "-c:v", "libx264", "-preset", "medium", "-crf", "18",
+                        "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                        "-x264-params", "rc-lookahead=10:sync-lookahead=0:bframes=0:threads=4",
                         "-pix_fmt", "yuv420p", "-c:a", "aac", "-shortest",
                         out_path,
                     ],
-                    stdin=subprocess.PIPE,
+                    stdin=subprocess.PIPE, stderr=subprocess.DEVNULL,
                 )
-            proc.stdin.write(up.tobytes())
+            try:
+                proc.stdin.write(up.tobytes())
+            except BrokenPipeError:
+                logger.error("upscale: ffmpeg closed the pipe at frame %d (encoder died)", i)
+                break
             i += 1
             if i % 12 == 0:
                 logger.info("upscale: %d/%d frames (%.1fs/frame)", i, total, (time.time() - t0) / i)
@@ -93,6 +101,7 @@ async def _upscale_video_job(scene_id: uuid.UUID, scale: int) -> None:
             src.write_bytes(data)
 
         n = await asyncio.to_thread(_process_video, str(src), str(out), scale)
+        get_face_restore_service().release()  # free the 5K-tile cache balloon
         if n == 0 or not out.exists():
             logger.error("upscale: produced no output for scene %s", scene_id)
             return

--- a/backend/vidpipe/api/upscale_routes.py
+++ b/backend/vidpipe/api/upscale_routes.py
@@ -1,0 +1,137 @@
+"""Opt-in 4K video upscaling (GPU, background).
+
+Upscales a scene's finished ``final.mp4`` to 4K with RealESRGAN (tiled, on the
+4070 Ti), frame by frame, re-muxing the original audio. This is deliberately a
+manual trigger, not part of the pipeline — it costs ~9 min of GPU per 6s of
+video. The result is saved as ``final_4k.mp4`` alongside the original.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import subprocess
+import time
+import uuid
+
+from fastapi import APIRouter, BackgroundTasks, HTTPException
+
+from vidpipe.db import async_session
+from vidpipe.db.models import Scene
+from vidpipe.services.face_restore_service import get_face_restore_service
+from vidpipe.services.file_manager import FileManager
+
+logger = logging.getLogger("vidpipe.upscale")
+
+upscale_router = APIRouter(prefix="/api", tags=["upscale"])
+
+
+def _process_video(src_path: str, out_path: str, scale: int) -> int:
+    """Decode → RealESRGAN upscale each frame → encode (libx264) + mux audio.
+
+    Streams raw frames straight to ffmpeg (no temp PNGs). Returns frame count.
+    Runs in a worker thread (blocking GPU + ffmpeg work).
+    """
+    import cv2
+    import numpy as np
+
+    rsvc = get_face_restore_service()
+    cap = cv2.VideoCapture(src_path)
+    fps = cap.get(cv2.CAP_PROP_FPS) or 24.0
+    total = int(cap.get(cv2.CAP_PROP_FRAME_COUNT) or 0)
+    proc = None
+    i = 0
+    t0 = time.time()
+    try:
+        while True:
+            ok, frame = cap.read()
+            if not ok:
+                break
+            ok_enc, buf = cv2.imencode(".png", frame)
+            up_png = rsvc.upscale(buf.tobytes(), scale) if ok_enc else None
+            if up_png:
+                up = cv2.imdecode(np.frombuffer(up_png, np.uint8), cv2.IMREAD_COLOR)
+            else:
+                up = cv2.resize(frame, None, fx=scale, fy=scale, interpolation=cv2.INTER_LANCZOS4)
+            if proc is None:
+                h, w = up.shape[:2]
+                proc = subprocess.Popen(
+                    [
+                        "ffmpeg", "-y",
+                        "-f", "rawvideo", "-pix_fmt", "bgr24",
+                        "-s", f"{w}x{h}", "-r", str(fps), "-i", "pipe:0",
+                        "-i", src_path,
+                        "-map", "0:v:0", "-map", "1:a:0?",
+                        "-c:v", "libx264", "-preset", "medium", "-crf", "18",
+                        "-pix_fmt", "yuv420p", "-c:a", "aac", "-shortest",
+                        out_path,
+                    ],
+                    stdin=subprocess.PIPE,
+                )
+            proc.stdin.write(up.tobytes())
+            i += 1
+            if i % 12 == 0:
+                logger.info("upscale: %d/%d frames (%.1fs/frame)", i, total, (time.time() - t0) / i)
+    finally:
+        cap.release()
+        if proc is not None:
+            proc.stdin.close()
+            proc.wait()
+    logger.info("upscale: encoded %d frames in %.1fs", i, time.time() - t0)
+    return i
+
+
+async def _upscale_video_job(scene_id: uuid.UUID, scale: int) -> None:
+    file_mgr = FileManager()
+    src = file_mgr.get_output_path(scene_id, "final.mp4")
+    out = file_mgr.get_output_path(scene_id, "final_4k.mp4")
+    try:
+        if not src.exists():
+            # Materialize from storage (S3) if the local copy is gone.
+            data = await file_mgr.read_bytes(f"{scene_id}/output/final.mp4")
+            src.parent.mkdir(parents=True, exist_ok=True)
+            src.write_bytes(data)
+
+        n = await asyncio.to_thread(_process_video, str(src), str(out), scale)
+        if n == 0 or not out.exists():
+            logger.error("upscale: produced no output for scene %s", scene_id)
+            return
+        key = f"{scene_id}/output/final_4k.mp4"
+        await file_mgr.backend.put(key, out.read_bytes(), "video/mp4")
+        logger.info("upscale: scene %s done → %s (%d frames)", scene_id, key, n)
+    except Exception as e:  # noqa: BLE001
+        logger.error("upscale: scene %s failed: %s", scene_id, e)
+
+
+@upscale_router.post("/scenes/{scene_id}/upscale-video", status_code=202)
+async def upscale_scene_video(scene_id: uuid.UUID, background_tasks: BackgroundTasks):
+    """Kick off a background 4K upscale of the scene's final video (opt-in, GPU)."""
+    async with async_session() as session:
+        scene = await session.get(Scene, scene_id)
+        if scene is None:
+            raise HTTPException(status_code=404, detail="Scene not found")
+
+    rsvc = get_face_restore_service()
+    if not await asyncio.to_thread(rsvc.has_upscale):
+        raise HTTPException(
+            status_code=503,
+            detail="Upscaler unavailable (GPU or RealESRGAN weight missing).",
+        )
+
+    file_mgr = FileManager()
+    has_local = file_mgr.get_output_path(scene_id, "final.mp4").exists()
+    if not has_local:
+        try:
+            await file_mgr.read_bytes(f"{scene_id}/output/final.mp4")
+        except Exception:
+            raise HTTPException(status_code=409, detail="Scene has no final video to upscale.")
+
+    from vidpipe.config import settings
+
+    background_tasks.add_task(_upscale_video_job, scene_id, settings.face_swap.upscale_scale)
+    return {
+        "scene_id": str(scene_id),
+        "status": "upscaling_started",
+        "note": "4K upscale runs in the background on the GPU (~9 min per 6s of video). "
+                "Result saved as final_4k.mp4 when complete.",
+    }

--- a/backend/vidpipe/config.py
+++ b/backend/vidpipe/config.py
@@ -68,6 +68,23 @@ class PipelineConfig(BaseModel):
     retry_max_attempts: int
     retry_base_delay: int
     video_transient_retries: int = 3
+    # Degenerate-clip detection (ComfyUI Cloud occasionally returns corrupted
+    # MP4s on successful jobs) — validate downloads and retry with a new job.
+    clip_validation_enabled: bool = True
+    clip_corrupt_retry_max: int = 2
+    # Near-static ComfyUI/LTX clips (frozen openings from "slow/steady" motion
+    # prompts) — minimum mean frame-diff to accept without escalation, and how
+    # many times to resubmit with a motion-amplified prompt. Frozen clips
+    # measure < 5; lively clips measure 7-37.
+    clip_min_motion: float = 5.0
+    clip_motion_retry_max: int = 1
+    # Max seconds a ComfyUI job may sit in a queue state ("queued_limited"
+    # under account concurrency limits) before we give up. Queue time does
+    # not count against execution poll timeouts.
+    comfy_queue_timeout: int = 1800
+    # Resume scenes orphaned in in-flight statuses when the server restarts
+    # (e.g. container rebuild mid-pipeline).
+    auto_resume_on_startup: bool = True
 
 
 class StorageConfig(BaseModel):
@@ -110,6 +127,28 @@ class CVAnalysisConfig(BaseModel):
     max_video_file_size_mb: int = 200
 
 
+class FaceSwapConfig(BaseModel):
+    """Post-generation face-swap configuration.
+
+    Pastes a character's real reference face onto generated keyframes
+    (InsightFace inswapper) to lock exact identity regardless of the image
+    model. Opt-in: existing productions are unaffected until enabled.
+    """
+
+    enabled: bool = False  # feature flag (opt-in)
+    min_det_score: float = 0.50  # skip swap when the target face detects below this
+    # Post-swap face restoration (CodeFormer via spandrel, GPU). Re-renders the
+    # soft 128px swapped face at 512px with realistic detail, then pastes back.
+    restore: bool = False
+    restore_weight: float = 0.9  # CodeFormer fidelity (→1.0 preserves identity; →0 max restoration)
+    restore_model_dir: str = "/models/restore"  # codeformer.pth + RealESRGAN_x4plus.pth live here
+    # Optional 4x super-resolution (RealESRGAN, GPU, tiled). Produces a separate
+    # *_4k still artifact — it does NOT replace the keyframe that feeds video gen
+    # (the video model downsamples; a 4K input would only bloat the cloud upload).
+    upscale_keyframes: bool = False
+    upscale_scale: int = 4
+
+
 class Settings(BaseSettings):
     """Main application settings with YAML and environment variable support.
 
@@ -133,6 +172,7 @@ class Settings(BaseSettings):
     storage: StorageConfig
     server: ServerConfig
     cv_analysis: CVAnalysisConfig = Field(default_factory=CVAnalysisConfig)
+    face_swap: FaceSwapConfig = Field(default_factory=FaceSwapConfig)
 
     @classmethod
     def settings_customise_sources(

--- a/backend/vidpipe/db/__init__.py
+++ b/backend/vidpipe/db/__init__.py
@@ -244,6 +244,8 @@ async def _run_migrations(conn) -> None:
         "ALTER TABLE keyframes ADD COLUMN verification_status VARCHAR(64)",
         "ALTER TABLE keyframes ADD COLUMN verification_attempts INTEGER DEFAULT 0",
         "ALTER TABLE keyframes ADD COLUMN verification_summary TEXT",
+        # Post-generation face-swap pass marker (idempotent resume)
+        "ALTER TABLE keyframes ADD COLUMN face_swapped BOOLEAN DEFAULT false",
     ]
     blob_type = "BLOB" if is_sqlite else "BYTEA"
 

--- a/backend/vidpipe/db/models.py
+++ b/backend/vidpipe/db/models.py
@@ -1168,6 +1168,11 @@ class Keyframe(Base):
     verification_status: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
     verification_attempts: Mapped[int] = mapped_column(Integer, default=0)
     verification_summary: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    # Post-generation face-swap pass marker (idempotent resume): True once the
+    # face-swap pass has finalized this keyframe (swapped or deliberately skipped).
+    face_swapped: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default=text("false")
+    )
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
 
 

--- a/backend/vidpipe/orchestrator/pipeline.py
+++ b/backend/vidpipe/orchestrator/pipeline.py
@@ -369,6 +369,11 @@ async def run_pipeline(
             except Exception as cp_err:
                 logger.warning(f"Failed to create auto-checkpoint: {cp_err}")
 
+        # Clear any stale error from a previous failed run that this
+        # (re)run has now recovered from
+        if scene.status == "complete" and scene.error_message:
+            scene.error_message = None
+
         # Finalize PipelineRun on success
         run.completed_at = datetime.utcnow()
         run.total_duration_seconds = time.monotonic() - pipeline_start

--- a/backend/vidpipe/orchestrator/pipeline.py
+++ b/backend/vidpipe/orchestrator/pipeline.py
@@ -263,6 +263,16 @@ async def run_pipeline(
         await session.commit()
         logger.info(f"Scene {scene.id}: transitioned from previous status to {resume_step}")
 
+    # Normalize the transient keyframes→video status. generate_keyframes sets
+    # "generating_video" and the orchestrator usually renames it to "video_gen"
+    # right after — but a crash/restart between the two leaves the scene
+    # stranded in a status no step block matches, so the pipeline would
+    # otherwise no-op straight to "completed successfully".
+    if scene.status == "generating_video":
+        scene.status = "video_gen"
+        await session.commit()
+        logger.info(f"Scene {scene.id}: normalized generating_video → video_gen")
+
     try:
         # Step 1: Storyboard generation
         if scene.status == "pending":

--- a/backend/vidpipe/orchestrator/recovery.py
+++ b/backend/vidpipe/orchestrator/recovery.py
@@ -1,0 +1,75 @@
+"""Startup recovery for scenes orphaned by a server restart.
+
+The pipeline runs as in-process background tasks. When the server restarts
+mid-run (e.g. a container rebuild), scenes are left stranded in an in-flight
+status with no task driving them — the UI shows them generating forever and
+the production never finishes. Every stage checkpoints to the database, so
+these scenes are safely resumable: ComfyUI jobs are re-polled via the
+persisted ``comfyui:`` operation id, completed stages are skipped.
+"""
+
+import logging
+import uuid
+
+from sqlalchemy import select
+
+from vidpipe.db import async_session
+from vidpipe.db.models import Scene
+from vidpipe.orchestrator.pipeline import run_pipeline
+
+logger = logging.getLogger(__name__)
+
+# Statuses that imply a pipeline task should be driving the scene
+IN_FLIGHT_STATUSES = (
+    "pending",
+    "storyboarding",
+    "keyframing",
+    "generating_video",
+    "video_gen",
+    "stitching",
+)
+
+
+async def find_orphaned_scene_ids() -> list[uuid.UUID]:
+    """Return ids of scenes stranded in in-flight statuses."""
+    async with async_session() as session:
+        result = await session.execute(
+            select(Scene.id)
+            .where(Scene.status.in_(IN_FLIGHT_STATUSES))
+            .where(Scene.deleted_at.is_(None))
+            .order_by(Scene.created_at)
+        )
+        return [row[0] for row in result]
+
+
+async def recover_orphaned_scenes() -> int:
+    """Resume every orphaned scene, sequentially.
+
+    Runs as a background task after startup. Failures are persisted per-scene
+    by the orchestrator (scene.status="failed" + error_message) and do not
+    stop recovery of the remaining scenes.
+
+    Returns:
+        Number of scenes for which recovery was attempted.
+    """
+    scene_ids = await find_orphaned_scene_ids()
+    if not scene_ids:
+        logger.info("Startup recovery: no orphaned in-flight scenes found")
+        return 0
+
+    logger.warning(
+        "Startup recovery: resuming %d scene(s) orphaned by a restart: %s",
+        len(scene_ids), [str(s) for s in scene_ids],
+    )
+    for scene_id in scene_ids:
+        async with async_session() as session:
+            try:
+                await run_pipeline(session, scene_id)
+                logger.info("Startup recovery: scene %s resumed to completion", scene_id)
+            except Exception as e:
+                # Error state already persisted by the orchestrator
+                logger.error(
+                    "Startup recovery: scene %s failed: %s: %s",
+                    scene_id, type(e).__name__, e,
+                )
+    return len(scene_ids)

--- a/backend/vidpipe/orchestrator/state.py
+++ b/backend/vidpipe/orchestrator/state.py
@@ -39,6 +39,9 @@ RESUMABLE_STATES = {
     "storyboarding",
     "keyframing",
     "video_gen",
+    # Transient status set by generate_keyframes; a crash/restart before the
+    # orchestrator normalizes it to "video_gen" leaves scenes stranded here.
+    "generating_video",
     "stitching",
 }
 
@@ -94,7 +97,7 @@ def get_resume_step(status: str, completed_steps: Dict[str, bool]) -> str:
         return "pending"
     elif status == "keyframing":
         return "keyframing"
-    elif status == "video_gen":
+    elif status in ("video_gen", "generating_video"):
         return "video_gen"
     elif status == "stitching":
         return "stitching"

--- a/backend/vidpipe/pipeline/keyframes.py
+++ b/backend/vidpipe/pipeline/keyframes.py
@@ -3521,3 +3521,7 @@ async def apply_scene_face_swaps(session: AsyncSession, scene: Scene) -> None:
         logger.info(
             "Face-swap: swapped %d keyframe(s) for scene %s", swapped_count, scene.id
         )
+    # Release the torch GPU cache used by per-keyframe restoration/upscale so the
+    # reserved pool doesn't linger between scenes (model weights stay resident).
+    if settings.face_swap.restore or settings.face_swap.upscale_keyframes:
+        get_face_restore_service().release()

--- a/backend/vidpipe/pipeline/keyframes.py
+++ b/backend/vidpipe/pipeline/keyframes.py
@@ -57,7 +57,20 @@ def _detect_image_mime(data: bytes) -> str:
 # ---------------------------------------------------------------------------
 # ComfyUI image models (routed to ComfyUI instead of Vertex AI)
 # ---------------------------------------------------------------------------
-COMFYUI_IMAGE_MODELS = {"qwen-fast", "qwen-image-edit", "flux-dev", "flux-dev-lora", "flux-dev-redux", "flux-dev-full"}
+COMFYUI_IMAGE_MODELS = {
+    "qwen-fast",
+    "qwen-image-edit",
+    "qwen-image-edit-2509",
+    "flux-dev",
+    "flux-dev-lora",
+    "flux-dev-redux",
+    "flux-dev-full",
+    "flux-2-klein",
+}
+# ComfyUI models that consume production-bible identity references via the
+# same reference-selection machinery as Nano Banana (face/wardrobe candidate
+# selection, identity policy, emphasis escalation, post-gen verification).
+COMFYUI_MULTIREF_IMAGE_MODELS = {"qwen-image-edit-2509", "flux-2-klein"}
 _NANO_BANANA_MAX_REFERENCE_IMAGES = 13
 
 # ---------------------------------------------------------------------------
@@ -1707,24 +1720,13 @@ async def _verify_keyframe_faces(
         return True, 0.0, f"verification_error: {e}"
 
 
-async def _generate_image_comfyui(
-    comfy_client,
-    prompt: str,
-    seed: int,
-    width: int = 1328,
-    height: int = 1328,
-) -> bytes:
-    """Generate an image via ComfyUI Cloud using the Qwen txt2img workflow.
-
-    Builds the workflow, queues it, polls until success, then downloads
-    the output image.
+async def _run_comfyui_image_job(comfy_client, workflow: dict, label: str) -> bytes:
+    """Queue a ComfyUI image workflow, poll until success, download the output.
 
     Args:
         comfy_client: ComfyUIClient instance
-        prompt: Text description for image generation
-        seed: Random seed for reproducibility
-        width: Image width (default 1328, Qwen native)
-        height: Image height (default 1328, Qwen native)
+        workflow: API-format workflow dict ready to submit
+        label: Human-readable job label for logging
 
     Returns:
         PNG image data as bytes
@@ -1733,16 +1735,10 @@ async def _generate_image_comfyui(
         RuntimeError: On ComfyUI job failure or timeout
         ValueError: If no image output found in history
     """
-    from vidpipe.services.comfyui_client import (
-        build_qwen_txt2img_workflow,
-        find_comfyui_image_output,
-    )
+    from vidpipe.services.comfyui_client import find_comfyui_image_output
 
-    workflow = build_qwen_txt2img_workflow(
-        prompt=prompt, width=width, height=height, seed=seed,
-    )
     prompt_id = await comfy_client.queue_prompt(workflow)
-    logger.info(f"ComfyUI Qwen txt2img queued: prompt_id={prompt_id}")
+    logger.info(f"ComfyUI {label} queued: prompt_id={prompt_id}")
 
     # Poll until completion (check for "success", not "completed")
     max_polls = 120
@@ -1754,12 +1750,12 @@ async def _generate_image_comfyui(
             break
         if status in ("error", "failed", "cancelled"):
             raise RuntimeError(
-                f"ComfyUI job {prompt_id} failed: status={status}, error={error_msg}"
+                f"ComfyUI {label} job {prompt_id} failed: status={status}, error={error_msg}"
             )
         # Still pending/in_progress — keep polling
     else:
         raise RuntimeError(
-            f"ComfyUI job {prompt_id} timed out after {max_polls * poll_interval}s"
+            f"ComfyUI {label} job {prompt_id} timed out after {max_polls * poll_interval}s"
         )
 
     # Fetch history and extract output image
@@ -1767,9 +1763,25 @@ async def _generate_image_comfyui(
     filename, subfolder = find_comfyui_image_output(history, prompt_id)
     image_bytes = await comfy_client.download_output(filename, subfolder)
     logger.info(
-        f"ComfyUI Qwen txt2img complete: {filename} ({len(image_bytes)} bytes)"
+        f"ComfyUI {label} complete: {filename} ({len(image_bytes)} bytes)"
     )
     return image_bytes
+
+
+async def _generate_image_comfyui(
+    comfy_client,
+    prompt: str,
+    seed: int,
+    width: int = 1328,
+    height: int = 1328,
+) -> bytes:
+    """Generate an image via ComfyUI Cloud using the Qwen txt2img workflow."""
+    from vidpipe.services.comfyui_client import build_qwen_txt2img_workflow
+
+    workflow = build_qwen_txt2img_workflow(
+        prompt=prompt, width=width, height=height, seed=seed,
+    )
+    return await _run_comfyui_image_job(comfy_client, workflow, "Qwen txt2img")
 
 
 async def _generate_image_comfyui_edit(
@@ -1780,63 +1792,17 @@ async def _generate_image_comfyui_edit(
 ) -> bytes:
     """Generate an edited image via ComfyUI Cloud using the Qwen Image Edit workflow.
 
-    Uploads the input image, builds the edit workflow, queues it, polls until
-    success, then downloads the output image.
-
-    Args:
-        comfy_client: ComfyUIClient instance
-        prompt: Edit instruction describing what to change
-        input_image_bytes: PNG/JPEG bytes of the image to edit
-        seed: Random seed for reproducibility
-
-    Returns:
-        PNG image data as bytes
-
-    Raises:
-        RuntimeError: On ComfyUI job failure or timeout
-        ValueError: If no image output found in history
+    Uploads the input image, builds the edit workflow, and runs the job.
     """
-    from vidpipe.services.comfyui_client import (
-        build_qwen_image_edit_workflow,
-        find_comfyui_image_output,
-    )
+    from vidpipe.services.comfyui_client import build_qwen_image_edit_workflow
 
-    # Upload the input image to ComfyUI
     input_filename = await comfy_client.upload_image(
         input_image_bytes, "image_qwen_image_edit_input_image.png"
     )
-
     workflow = build_qwen_image_edit_workflow(
         prompt=prompt, input_image_filename=input_filename, seed=seed,
     )
-    prompt_id = await comfy_client.queue_prompt(workflow)
-    logger.info(f"ComfyUI Qwen Image Edit queued: prompt_id={prompt_id}")
-
-    # Poll until completion
-    max_polls = 120
-    poll_interval = 3
-    for attempt in range(max_polls):
-        await asyncio.sleep(poll_interval)
-        status, error_msg = await comfy_client.poll_status(prompt_id)
-        if status == "success":
-            break
-        if status in ("error", "failed", "cancelled"):
-            raise RuntimeError(
-                f"ComfyUI job {prompt_id} failed: status={status}, error={error_msg}"
-            )
-    else:
-        raise RuntimeError(
-            f"ComfyUI job {prompt_id} timed out after {max_polls * poll_interval}s"
-        )
-
-    # Fetch history and extract output image
-    history = await comfy_client.get_history(prompt_id)
-    filename, subfolder = find_comfyui_image_output(history, prompt_id)
-    image_bytes = await comfy_client.download_output(filename, subfolder)
-    logger.info(
-        f"ComfyUI Qwen Image Edit complete: {filename} ({len(image_bytes)} bytes)"
-    )
-    return image_bytes
+    return await _run_comfyui_image_job(comfy_client, workflow, "Qwen Image Edit")
 
 
 async def _generate_image_comfyui_flux(
@@ -1852,32 +1818,10 @@ async def _generate_image_comfyui_flux(
 ) -> bytes:
     """Generate an image via ComfyUI Cloud using the Flux.1 Dev txt2img workflow.
 
-    Builds the workflow with optional LoRA and reference images, queues it,
-    polls until success, then downloads the output image.
-
-    Args:
-        comfy_client: ComfyUIClient instance
-        prompt: Text description for image generation
-        seed: Random seed for reproducibility
-        width: Image width (default 1024)
-        height: Image height (default 1024)
-        lora_filename: Optional LoRA .safetensors filename on ComfyUI server
-        lora_strength: LoRA strength (default 0.8)
-        reference_image_filenames: Optional list of uploaded reference image
-            filenames on the ComfyUI server (max 3)
-        reference_strengths: Optional per-reference conditioning strengths
-
-    Returns:
-        PNG image data as bytes
-
-    Raises:
-        RuntimeError: On ComfyUI job failure or timeout
-        ValueError: If no image output found in history
+    Builds the workflow with optional LoRA and reference images (max 3,
+    pre-uploaded filenames) and runs the job.
     """
-    from vidpipe.services.comfyui_client import (
-        build_flux_txt2img_workflow,
-        find_comfyui_image_output,
-    )
+    from vidpipe.services.comfyui_client import build_flux_txt2img_workflow
 
     workflow = build_flux_txt2img_workflow(
         prompt=prompt,
@@ -1889,35 +1833,85 @@ async def _generate_image_comfyui_flux(
         reference_image_filenames=reference_image_filenames,
         reference_strengths=reference_strengths,
     )
-    prompt_id = await comfy_client.queue_prompt(workflow)
-    logger.info(f"ComfyUI Flux txt2img queued: prompt_id={prompt_id}")
+    return await _run_comfyui_image_job(comfy_client, workflow, "Flux txt2img")
 
-    # Poll until completion
-    max_polls = 120
-    poll_interval = 3
-    for attempt in range(max_polls):
-        await asyncio.sleep(poll_interval)
-        status, error_msg = await comfy_client.poll_status(prompt_id)
-        if status == "success":
-            break
-        if status in ("error", "failed", "cancelled"):
-            raise RuntimeError(
-                f"ComfyUI Flux job {prompt_id} failed: status={status}, error={error_msg}"
-            )
-        # Still pending/in_progress — keep polling
-    else:
-        raise RuntimeError(
-            f"ComfyUI Flux job {prompt_id} timed out after {max_polls * poll_interval}s"
+
+async def _generate_image_comfyui_qwen_edit_2509(
+    comfy_client,
+    prompt: str,
+    seed: int,
+    image_bytes_list: list[bytes],
+    output_width: Optional[int] = None,
+    output_height: Optional[int] = None,
+) -> bytes:
+    """Generate an image via Qwen Image Edit 2509 with 1-3 input images.
+
+    Uploads each input image, builds the multi-ref edit workflow, and runs
+    the job. The first image is image1: in edit mode (no output dims) the
+    output size follows it; in generation mode (output dims given) the output
+    uses the requested dimensions and the images act purely as references.
+
+    Args:
+        comfy_client: ComfyUIClient instance
+        prompt: Edit/composition instruction
+        seed: Random seed for reproducibility
+        image_bytes_list: 1-3 input images as PNG/JPEG bytes
+        output_width: Explicit output width (generation mode)
+        output_height: Explicit output height (generation mode)
+    """
+    from vidpipe.services.comfyui_client import build_qwen_edit_2509_workflow
+
+    filenames = []
+    for i, img_bytes in enumerate(image_bytes_list[:3]):
+        filenames.append(
+            await comfy_client.upload_image(img_bytes, f"qwen2509_image{i + 1}.png")
         )
-
-    # Fetch history and extract output image
-    history = await comfy_client.get_history(prompt_id)
-    filename, subfolder = find_comfyui_image_output(history, prompt_id)
-    image_bytes = await comfy_client.download_output(filename, subfolder)
-    logger.info(
-        f"ComfyUI Flux txt2img complete: {filename} ({len(image_bytes)} bytes)"
+    workflow = build_qwen_edit_2509_workflow(
+        prompt=prompt,
+        image_filenames=filenames,
+        seed=seed,
+        output_width=output_width,
+        output_height=output_height,
     )
-    return image_bytes
+    return await _run_comfyui_image_job(comfy_client, workflow, "Qwen Edit 2509")
+
+
+async def _generate_image_comfyui_flux2_klein(
+    comfy_client,
+    prompt: str,
+    seed: int,
+    width: int = 1024,
+    height: int = 1024,
+    reference_image_bytes_list: Optional[list[bytes]] = None,
+) -> bytes:
+    """Generate an image via FLUX.2 Klein 4B with 0-4 reference images.
+
+    Uploads each reference image, builds the klein workflow (plain txt2img
+    when no references), and runs the job.
+
+    Args:
+        comfy_client: ComfyUIClient instance
+        prompt: Positive prompt text
+        seed: Random seed for reproducibility
+        width: Output width in pixels
+        height: Output height in pixels
+        reference_image_bytes_list: Up to 4 reference images as PNG/JPEG bytes
+    """
+    from vidpipe.services.comfyui_client import build_flux2_klein_workflow
+
+    filenames = []
+    for i, img_bytes in enumerate((reference_image_bytes_list or [])[:4]):
+        filenames.append(
+            await comfy_client.upload_image(img_bytes, f"flux2_ref{i + 1}.png")
+        )
+    workflow = build_flux2_klein_workflow(
+        prompt=prompt,
+        width=width,
+        height=height,
+        seed=seed,
+        reference_image_filenames=filenames or None,
+    )
+    return await _run_comfyui_image_job(comfy_client, workflow, "FLUX.2 Klein")
 
 
 async def generate_keyframes(
@@ -2149,7 +2143,9 @@ async def generate_keyframes(
                             f"(refs: {selected_reference_tags})"
                         )
 
-                    if not is_comfyui and _is_nano_banana_model(image_model):
+                    if (
+                        not is_comfyui and _is_nano_banana_model(image_model)
+                    ) or image_model in COMFYUI_MULTIREF_IMAGE_MODELS:
                         selected_tags = (
                             list(shot_manifest_row.selected_reference_tags or [])
                             if shot_manifest_row and shot_manifest_row.selected_reference_tags
@@ -2367,7 +2363,42 @@ async def generate_keyframes(
                     if start_retry_guidance:
                         prompt_with_emphasis = f"{start_retry_guidance}\n\n{prompt_with_emphasis}"
                     try:
-                        if is_comfyui and image_model.startswith("flux-"):
+                        if image_model == "qwen-image-edit-2509":
+                            # Multi-ref edit model: compose start frame from
+                            # identity references at the scene aspect ratio.
+                            from vidpipe.services.comfyui_client import _QWEN_RESOLUTIONS
+                            qw, qh = _QWEN_RESOLUTIONS.get(scene.aspect_ratio, (1328, 1328))
+                            if attempt_ref_image_bytes:
+                                compose_prompt = (
+                                    "Using the people, characters, and objects shown in the "
+                                    "input images as exact identity references, create a new "
+                                    f"scene: {prompt_with_emphasis}"
+                                )
+                                start_frame_bytes = await _generate_image_comfyui_qwen_edit_2509(
+                                    comfy_client, compose_prompt, seed=base_seed,
+                                    image_bytes_list=attempt_ref_image_bytes[:3],
+                                    output_width=qw, output_height=qh,
+                                )
+                            else:
+                                # Edit model needs input images; without refs
+                                # fall back to qwen txt2img at scene aspect.
+                                logger.info(
+                                    f"Shot {shot.shot_index}: qwen-image-edit-2509 has no "
+                                    "reference images, falling back to qwen txt2img"
+                                )
+                                start_frame_bytes = await _generate_image_comfyui(
+                                    comfy_client, prompt_with_emphasis, seed=base_seed,
+                                    width=qw, height=qh,
+                                )
+                        elif image_model == "flux-2-klein":
+                            from vidpipe.services.comfyui_client import _FLUX2_RESOLUTIONS
+                            f2w, f2h = _FLUX2_RESOLUTIONS.get(scene.aspect_ratio, (1024, 1024))
+                            start_frame_bytes = await _generate_image_comfyui_flux2_klein(
+                                comfy_client, prompt_with_emphasis, seed=base_seed,
+                                width=f2w, height=f2h,
+                                reference_image_bytes_list=attempt_ref_image_bytes[:4] or None,
+                            )
+                        elif is_comfyui and image_model.startswith("flux-"):
                             # Flux model: use binding-based reference resolution
                             flux_lora = None
                             flux_ref_filenames: list[str] = []
@@ -2696,7 +2727,28 @@ async def generate_keyframes(
                     if end_retry_guidance:
                         prompt_with_emphasis = f"{end_retry_guidance}\n\n{prompt_with_emphasis}"
                     try:
-                        if is_comfyui and image_model.startswith("flux-"):
+                        if image_model == "qwen-image-edit-2509":
+                            # Multi-ref edit: image1 = start frame (drives output
+                            # dimensions + visual conditioning), image2/3 = identity refs.
+                            end_frame_bytes = await _generate_image_comfyui_qwen_edit_2509(
+                                comfy_client, prompt_with_emphasis,
+                                seed=base_seed + shot.shot_index + 1000,
+                                image_bytes_list=[start_frame_bytes] + list(attempt_ref_image_bytes[:2]),
+                            )
+                        elif image_model == "flux-2-klein":
+                            # Ref slot 1 = start frame (visual conditioning),
+                            # slots 2-4 = identity refs.
+                            from vidpipe.services.comfyui_client import _FLUX2_RESOLUTIONS as _F2R
+                            ef2w, ef2h = _F2R.get(scene.aspect_ratio, (1024, 1024))
+                            end_frame_bytes = await _generate_image_comfyui_flux2_klein(
+                                comfy_client, prompt_with_emphasis,
+                                seed=base_seed + shot.shot_index + 1000,
+                                width=ef2w, height=ef2h,
+                                reference_image_bytes_list=(
+                                    [start_frame_bytes] + list(attempt_ref_image_bytes[:3])
+                                ),
+                            )
+                        elif is_comfyui and image_model.startswith("flux-"):
                             # Flux model: text-only (no image conditioning), offset seed
                             # Reuse binding-resolved LoRA/refs if available from start frame
                             from vidpipe.services.comfyui_client import _FLUX_RESOLUTIONS as _FR

--- a/backend/vidpipe/pipeline/keyframes.py
+++ b/backend/vidpipe/pipeline/keyframes.py
@@ -31,7 +31,7 @@ from tenacity import (
 )
 
 from vidpipe.config import settings
-from vidpipe.db.models import Asset, Scene, Shot, Keyframe
+from vidpipe.db.models import DEFAULT_USER_ID, Asset, Scene, Shot, Keyframe, UserSettings
 from vidpipe.schemas.llm_vision import CharacterKeyframeVerificationOutput
 from vidpipe.services.event_bus import emit_task_log
 from vidpipe.services.file_manager import FileManager
@@ -72,6 +72,11 @@ COMFYUI_IMAGE_MODELS = {
 # selection, identity policy, emphasis escalation, post-gen verification).
 COMFYUI_MULTIREF_IMAGE_MODELS = {"qwen-image-edit-2509", "flux-2-klein"}
 _NANO_BANANA_MAX_REFERENCE_IMAGES = 13
+
+
+def _uses_comfyui_vision_primary(scene: object) -> bool:
+    return getattr(scene, "image_model", None) in COMFYUI_MULTIREF_IMAGE_MODELS
+
 
 # ---------------------------------------------------------------------------
 # Identity emphasis escalation prefixes for face verification retry
@@ -253,6 +258,10 @@ class _CharacterVerificationTarget:
     tag: str
     identity_type: str
     expected_position: str | None = None
+    # Authoritative wardrobe for this shot (from the manifest placement).
+    # When set, wardrobe is judged against this text — NOT against the
+    # clothing worn in the identity reference photos.
+    expected_wardrobe: str | None = None
     face_candidates: list[_ReferenceCandidate] = field(default_factory=list)
     wardrobe_candidates: list[_ReferenceCandidate] = field(default_factory=list)
     fallback_candidates: list[_ReferenceCandidate] = field(default_factory=list)
@@ -393,10 +402,13 @@ def _build_character_verification_targets(
     identity_types_by_tag: dict[str, str],
 ) -> list[_CharacterVerificationTarget]:
     positions_by_tag: dict[str, str | None] = {}
+    wardrobe_by_tag: dict[str, str | None] = {}
     for placement in (shot_manifest_json or {}).get("placements", []):
         tag = _normalize_reference_tag(placement.get("asset_tag"))
         if tag and tag not in positions_by_tag:
             positions_by_tag[tag] = placement.get("position")
+        if tag and placement.get("wardrobe_note") and tag not in wardrobe_by_tag:
+            wardrobe_by_tag[tag] = placement.get("wardrobe_note")
 
     targets: dict[str, _CharacterVerificationTarget] = {}
     for candidate in selected_candidates:
@@ -408,6 +420,7 @@ def _build_character_verification_targets(
                 tag=candidate.tag,
                 identity_type=identity_types_by_tag.get(candidate.tag, candidate.identity_type or "HUMAN"),
                 expected_position=positions_by_tag.get(candidate.tag),
+                expected_wardrobe=wardrobe_by_tag.get(candidate.tag),
             ),
         )
         if candidate.reference_kind == "face":
@@ -630,6 +643,135 @@ def _passes_partial_visibility_human_check(
     if result.wardrobe_score < 6.0:
         return False
     return _issues_indicate_visibility_limited_identity(result.issues)
+
+
+def _vision_can_corroborate_near_threshold_face(
+    *,
+    face_result: _HumanFaceVerificationResult,
+    vision_result: _CharacterVisionVerificationResult | None,
+) -> bool:
+    if face_result.passed or face_result.advisory:
+        return False
+    if vision_result is None:
+        return False
+    if not (
+        vision_result.passed
+        and vision_result.character_visible
+        and vision_result.identity_match
+        and vision_result.wardrobe_match
+    ):
+        return False
+    if vision_result.identity_score < 8.0 or vision_result.wardrobe_score < 7.0:
+        return False
+
+    threshold = settings.cv_analysis.keyframe_face_match_threshold
+    # Historical references and generated documentary frames often miss the
+    # embedding threshold on expression/pose while the multimodal verifier still
+    # sees a clean identity match. Keep the band narrow enough to reject weak
+    # matches, but wide enough to avoid burning repeated provider calls on
+    # clean 8+/10 vision passes.
+    near_threshold_margin = max(0.07, threshold * 0.15)
+    return face_result.similarity >= threshold - near_threshold_margin
+
+
+def _compose_numbered_reference_board(image_bytes_list: list[bytes]) -> bytes:
+    """Compose candidate reference images into one numbered horizontal board."""
+    from PIL import Image, ImageDraw
+
+    panel = 320
+    tiles = []
+    for raw in image_bytes_list:
+        img = Image.open(io.BytesIO(raw)).convert("RGB")
+        img.thumbnail((panel, panel))
+        tiles.append(img)
+    board = Image.new("RGB", (panel * len(tiles), panel + 28), (16, 16, 16))
+    draw = ImageDraw.Draw(board)
+    for i, tile in enumerate(tiles):
+        board.paste(tile, (i * panel, 28))
+        draw.text((i * panel + 6, 4), f"IMAGE {i}", fill=(255, 255, 0))
+    buf = io.BytesIO()
+    board.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+async def _qualify_multiref_identity_candidates(
+    *,
+    session: AsyncSession,
+    scene: Scene,
+    candidates: list,
+    max_character_refs: int = 2,
+) -> tuple[list, str]:
+    """Pick the best CHARACTER reference images for multi-ref ComfyUI models.
+
+    Occluded references (sunglasses, faces turned away) dilute identity
+    conditioning in reference-latent models — observed: a lead character
+    rendered as a different person when sunglasses selfies were mixed into
+    the reference set. One vision call rates each candidate; the top
+    ``max_character_refs`` clear-face references are kept. Non-character
+    candidates pass through untouched. Any failure falls back to capping
+    the character refs in their original order.
+    """
+    from vidpipe.schemas.llm_vision import IdentityReferenceQualificationOutput
+
+    char_candidates = [c for c in candidates if c.asset_type == "CHARACTER"]
+    other_candidates = [c for c in candidates if c.asset_type != "CHARACTER"]
+    if len(char_candidates) <= max_character_refs:
+        return candidates, "qualification_skipped: at or under character ref cap"
+
+    fallback = char_candidates[:max_character_refs] + other_candidates
+
+    try:
+        vision_model_id = scene.vision_model or scene.text_model or settings.models.storyboard_llm
+        user_settings = None
+        if vision_model_id.startswith("ollama/"):
+            result = await session.execute(
+                select(UserSettings).where(UserSettings.user_id == DEFAULT_USER_ID)
+            )
+            user_settings = result.scalar_one_or_none()
+        vision_adapter = get_adapter(vision_model_id, user_settings=user_settings)
+
+        board = _compose_numbered_reference_board(
+            [c.image_bytes for c in char_candidates]
+        )
+        result = await vision_adapter.analyze_image(
+            board,
+            (
+                f"The board contains {len(char_candidates)} numbered photos of the same "
+                "person, candidates for use as identity reference images in image "
+                "generation. Rate each numbered panel for identity-reference "
+                "suitability. Penalize sunglasses, occluded or averted faces, and "
+                "blur. Reward sharp, frontal, unobstructed faces."
+            ),
+            IdentityReferenceQualificationOutput,
+            mime_type="image/png",
+            temperature=0.1,
+            max_retries=2,
+        )
+        rated = {
+            r.index: r for r in result.ratings if 0 <= r.index < len(char_candidates)
+        }
+        if not rated:
+            return fallback, "qualification_fallback: vision returned no usable ratings"
+
+        def _rank_key(i: int) -> tuple:
+            r = rated.get(i)
+            if r is None:
+                return (0, 0, 0.0)
+            return (int(r.face_clearly_visible), int(r.eyes_unobstructed), r.suitability)
+
+        order = sorted(range(len(char_candidates)), key=_rank_key, reverse=True)
+        keep = sorted(order[:max_character_refs])
+        detail = "; ".join(
+            f"img{i}: visible={rated[i].face_clearly_visible} "
+            f"eyes={rated[i].eyes_unobstructed} score={rated[i].suitability:.1f}"
+            f"{' KEPT' if i in keep else ''}"
+            for i in sorted(rated)
+        )
+        selected = [char_candidates[i] for i in keep] + other_candidates
+        return selected, f"qualification_ok: {detail}"
+    except Exception as exc:
+        logger.warning("Identity ref qualification failed (non-fatal): %s", exc)
+        return fallback, f"qualification_fallback: {exc}"
 
 
 def _pack_mandatory_reference_candidates(
@@ -1119,6 +1261,26 @@ def _select_character_candidate_boxes(
     return plan
 
 
+def _full_frame_character_crop_plan(
+    keyframe_bytes: bytes,
+    targets: list[_CharacterVerificationTarget],
+) -> _CharacterCropPlan:
+    return _CharacterCropPlan(
+        selections={
+            target.tag: _CharacterCropSelection(
+                tag=target.tag,
+                image_bytes=keyframe_bytes,
+                bbox=None,
+                used_full_frame=True,
+            )
+            for target in targets
+        },
+        detected_face_count=0,
+        detected_person_count=0,
+        detected_object_count=0,
+    )
+
+
 def _compose_verification_board(
     subject_bytes: bytes,
     references: list[tuple[str, bytes]],
@@ -1161,6 +1323,7 @@ def _compose_verification_board(
 
 async def _verify_keyframe_characters_with_vision(
     *,
+    session: AsyncSession,
     scene: Scene,
     shot: Shot,
     shot_manifest_json: dict | None,
@@ -1178,7 +1341,13 @@ async def _verify_keyframe_characters_with_vision(
 
     try:
         vision_model_id = scene.vision_model or scene.text_model or settings.models.storyboard_llm
-        vision_adapter = get_adapter(vision_model_id)
+        user_settings = None
+        if vision_model_id.startswith("ollama/"):
+            result = await session.execute(
+                select(UserSettings).where(UserSettings.user_id == DEFAULT_USER_ID)
+            )
+            user_settings = result.scalar_one_or_none()
+        vision_adapter = get_adapter(vision_model_id, user_settings=user_settings)
     except Exception as exc:
         logger.warning("Vision verifier unavailable (non-fatal): %s", exc)
         return _VisionVerificationReport(
@@ -1186,7 +1355,10 @@ async def _verify_keyframe_characters_with_vision(
             detail=f"vision_adapter_unavailable: {exc}",
         )
 
-    crop_plan = _select_character_candidate_boxes(keyframe_bytes, targets)
+    if _uses_comfyui_vision_primary(scene):
+        crop_plan = _full_frame_character_crop_plan(keyframe_bytes, targets)
+    else:
+        crop_plan = _select_character_candidate_boxes(keyframe_bytes, targets)
     detail_lines: list[str] = []
     overall_pass = True
     results: list[_CharacterVisionVerificationResult] = []
@@ -1210,11 +1382,25 @@ async def _verify_keyframe_characters_with_vision(
 
         board_bytes = _compose_verification_board(crop.image_bytes, references)
         expected_position = target.expected_position or "unspecified"
+        if target.expected_wardrobe and not target.wardrobe_candidates:
+            # Scene-specific costume: the identity photos establish WHO the
+            # person is, not what they wear in this shot. Without this, the
+            # verifier fails correct costumes for not matching the street
+            # clothes in the reference photos.
+            wardrobe_clause = (
+                f"Expected wardrobe for this shot (authoritative): "
+                f"'{target.expected_wardrobe}'. Judge wardrobe against that "
+                "description ONLY — the reference photos establish identity, "
+                "and the clothing worn in them is NOT the expected wardrobe. "
+            )
+        else:
+            wardrobe_clause = "Judge wardrobe/look fidelity against the reference images. "
         prompt = (
             f"Verify a generated keyframe crop for @{target.tag}. "
             f"Expected position: {expected_position}. "
             f"Identity type: {target.identity_type}. "
-            f"Judge only this character's identity/species/markings and wardrobe/look fidelity. "
+            f"Judge this character's identity/species/markings against the reference images. "
+            f"{wardrobe_clause}"
             f"Ignore camera angle, pose, lighting, and composition changes unless they hide the character completely. "
             f"The left panel is the generated crop. The right panels are reference images."
         )
@@ -1372,6 +1558,7 @@ def _build_retry_correction_prompt(report: _KeyframeVerificationReport) -> str:
 
 async def _verify_generated_keyframe(
     *,
+    session: AsyncSession,
     scene: Scene,
     shot: Shot,
     position: str,
@@ -1388,8 +1575,13 @@ async def _verify_generated_keyframe(
         selected_candidates=selected_candidates,
         identity_types_by_tag=identity_types_by_tag,
     )
-    crop_plan = _select_character_candidate_boxes(keyframe_bytes, targets)
+    comfyui_multiref_vision_primary = _uses_comfyui_vision_primary(scene)
+    if comfyui_multiref_vision_primary:
+        crop_plan = _full_frame_character_crop_plan(keyframe_bytes, targets)
+    else:
+        crop_plan = _select_character_candidate_boxes(keyframe_bytes, targets)
     vision_report = await _verify_keyframe_characters_with_vision(
+        session=session,
         scene=scene,
         shot=shot,
         shot_manifest_json=shot_manifest_json,
@@ -1413,6 +1605,7 @@ async def _verify_generated_keyframe(
             ).used_full_frame
             for target in human_targets
         )
+        or comfyui_multiref_vision_primary
     )
     verification_mode = (
         "vision_primary_face_advisory" if crowded else "strict_face_and_vision"
@@ -1430,10 +1623,15 @@ async def _verify_generated_keyframe(
             target.tag,
             _CharacterCropSelection(target.tag, keyframe_bytes, None, True),
         )
-        face_pass, sim, face_detail = await _verify_target_face(
-            crop.image_bytes,
-            reference_face_embeddings_by_tag.get(target.tag, []),
-        )
+        if comfyui_multiref_vision_primary:
+            face_pass = False
+            sim = 0.0
+            face_detail = "skipped_for_comfyui_vision_primary"
+        else:
+            face_pass, sim, face_detail = await _verify_target_face(
+                crop.image_bytes,
+                reference_face_embeddings_by_tag.get(target.tag, []),
+            )
         advisory = crowded or crop.used_full_frame
         if not advisory:
             face_gate_pass = face_gate_pass and face_pass
@@ -1459,6 +1657,35 @@ async def _verify_generated_keyframe(
         )
 
     checks.append(f"vision_check={vision_report.passed} {vision_report.detail}")
+    vision_results_by_tag = {
+        result.tag: result
+        for result in (vision_report.results if vision_report else [])
+    }
+    corroborated_face_tags = [
+        face_result.tag
+        for face_result in face_results
+        if _vision_can_corroborate_near_threshold_face(
+            face_result=face_result,
+            vision_result=vision_results_by_tag.get(face_result.tag),
+        )
+    ]
+    if not face_gate_pass and corroborated_face_tags:
+        blocking_face_tags = [
+            face_result.tag
+            for face_result in face_results
+            if (
+                not face_result.passed
+                and not face_result.advisory
+                and face_result.tag not in corroborated_face_tags
+            )
+        ]
+        if not blocking_face_tags:
+            face_gate_pass = True
+            checks.append(
+                "vision_corroborated_near_threshold_face="
+                + ",".join(f"@{tag}" for tag in corroborated_face_tags)
+            )
+
     overall_pass = bool(vision_report.passed and face_gate_pass)
 
     detail = " || ".join(checks) if checks else "no_checks"
@@ -1470,6 +1697,55 @@ async def _verify_generated_keyframe(
         face_results=face_results,
         vision_report=vision_report,
     )
+
+
+_ASPECT_RATIOS: dict[str, float] = {
+    "16:9": 16 / 9,
+    "9:16": 9 / 16,
+    "1:1": 1.0,
+    "4:3": 4 / 3,
+    "3:4": 3 / 4,
+    "21:9": 21 / 9,
+}
+
+
+def _coerce_image_aspect(image_bytes: bytes, aspect_ratio: str) -> bytes:
+    """Crop a generated image to the requested aspect ratio if it deviates.
+
+    Safety net for image models that occasionally ignore the aspect config
+    (observed: portrait keyframes for a 16:9 scene, later squashed into the
+    video resolution — the "fisheye" look). Crops are biased toward the top
+    of the frame when trimming height, since faces sit in the upper half.
+    """
+    target = _ASPECT_RATIOS.get(aspect_ratio)
+    if target is None:
+        return image_bytes
+
+    from PIL import Image
+
+    img = Image.open(io.BytesIO(image_bytes))
+    actual = img.width / img.height
+    if abs(actual - target) / target < 0.05:
+        return image_bytes
+
+    logger.warning(
+        "Generated image aspect %.3f deviates from requested %s (%.3f) — cropping",
+        actual, aspect_ratio, target,
+    )
+    if actual > target:
+        # Too wide — trim width, centered
+        new_w = int(img.height * target)
+        x0 = (img.width - new_w) // 2
+        img = img.crop((x0, 0, x0 + new_w, img.height))
+    else:
+        # Too tall — trim height, biased toward the top (faces live there)
+        new_h = int(img.width / target)
+        y0 = min(int((img.height - new_h) * 0.25), img.height - new_h)
+        img = img.crop((0, y0, img.width, y0 + new_h))
+
+    out = io.BytesIO()
+    img.convert("RGB").save(out, format="PNG")
+    return out.getvalue()
 
 
 @retry(
@@ -1529,12 +1805,16 @@ async def _generate_image_from_text(
         contents=contents,
         config=types.GenerateContentConfig(
             response_modalities=["IMAGE"],
+            # Without an explicit aspect ratio, Gemini image models follow the
+            # aspect of the reference images (a portrait selfie produced
+            # portrait keyframes that were then squashed into 16:9 video).
+            image_config=types.ImageConfig(aspect_ratio=aspect_ratio),
         ),
     )
 
     for part in response.candidates[0].content.parts:
         if part.inline_data:
-            return part.inline_data.data
+            return _coerce_image_aspect(part.inline_data.data, aspect_ratio)
 
     raise ValueError("No image generated in response")
 
@@ -1598,13 +1878,16 @@ async def _generate_image_conditioned(
         contents=contents,
         config=types.GenerateContentConfig(
             response_modalities=["IMAGE"],
+            # See _generate_image_from_text — explicit aspect ratio prevents
+            # the model from following the reference images' aspect.
+            image_config=types.ImageConfig(aspect_ratio=aspect_ratio),
         ),
     )
 
     # Extract image bytes from response
     for part in response.candidates[0].content.parts:
         if part.inline_data:
-            return part.inline_data.data
+            return _coerce_image_aspect(part.inline_data.data, aspect_ratio)
 
     raise ValueError("No image generated in response")
 
@@ -1735,15 +2018,22 @@ async def _run_comfyui_image_job(comfy_client, workflow: dict, label: str) -> by
         RuntimeError: On ComfyUI job failure or timeout
         ValueError: If no image output found in history
     """
+    import time as _time
+
+    from vidpipe.services.comfyui_adapter import QUEUED_STATUSES
     from vidpipe.services.comfyui_client import find_comfyui_image_output
 
     prompt_id = await comfy_client.queue_prompt(workflow)
     logger.info(f"ComfyUI {label} queued: prompt_id={prompt_id}")
 
-    # Poll until completion (check for "success", not "completed")
+    # Poll until completion (check for "success", not "completed").
+    # Time spent in Comfy Cloud queue states ("queued_limited" under account
+    # concurrency limits) does not count against the execution timeout.
     max_polls = 120
     poll_interval = 3
-    for attempt in range(max_polls):
+    polls_used = 0
+    queue_deadline = _time.monotonic() + settings.pipeline.comfy_queue_timeout
+    while True:
         await asyncio.sleep(poll_interval)
         status, error_msg = await comfy_client.poll_status(prompt_id)
         if status == "success":
@@ -1752,11 +2042,20 @@ async def _run_comfyui_image_job(comfy_client, workflow: dict, label: str) -> by
             raise RuntimeError(
                 f"ComfyUI {label} job {prompt_id} failed: status={status}, error={error_msg}"
             )
-        # Still pending/in_progress — keep polling
-    else:
-        raise RuntimeError(
-            f"ComfyUI {label} job {prompt_id} timed out after {max_polls * poll_interval}s"
-        )
+        if status in QUEUED_STATUSES:
+            if _time.monotonic() > queue_deadline:
+                raise RuntimeError(
+                    f"ComfyUI {label} job {prompt_id} stayed queued for more than "
+                    f"{settings.pipeline.comfy_queue_timeout}s"
+                )
+            continue
+        # Executing — consume execution poll budget
+        polls_used += 1
+        if polls_used >= max_polls:
+            raise RuntimeError(
+                f"ComfyUI {label} job {prompt_id} timed out after "
+                f"{max_polls * poll_interval}s of execution"
+            )
 
     # Fetch history and extract output image
     history = await comfy_client.get_history(prompt_id)
@@ -2145,7 +2444,7 @@ async def generate_keyframes(
 
                     if (
                         not is_comfyui and _is_nano_banana_model(image_model)
-                    ) or image_model in COMFYUI_MULTIREF_IMAGE_MODELS:
+                    ) or _uses_comfyui_vision_primary(scene):
                         selected_tags = (
                             list(shot_manifest_row.selected_reference_tags or [])
                             if shot_manifest_row and shot_manifest_row.selected_reference_tags
@@ -2252,7 +2551,43 @@ async def generate_keyframes(
                 if candidate.asset_type == "CHARACTER"
             ] if ref_image_bytes_list else []
 
-            if ref_image_bytes_list:
+            if ref_image_bytes_list and _uses_comfyui_vision_primary(scene):
+                logger.info(
+                    "Shot %s: skipping local face prequalification for ComfyUI multi-ref model %s",
+                    shot.shot_index,
+                    scene.image_model,
+                )
+                # Occluded refs (sunglasses, averted faces) dilute identity
+                # conditioning in reference-latent models — qualify the
+                # character refs and keep only the clearest faces.
+                qualified_candidates, qualification_detail = (
+                    await _qualify_multiref_identity_candidates(
+                        session=session,
+                        scene=scene,
+                        candidates=list(getattr(ref_context, "selected_candidates", [])),
+                    )
+                )
+                ref_context.selected_candidates = list(qualified_candidates)
+                ref_image_bytes_list = [c.image_bytes for c in qualified_candidates]
+                emit_task_log(
+                    scene.id,
+                    summary=(
+                        f"Shot {shot.shot_index + 1}: qualified "
+                        f"{len(ref_image_bytes_list)} reference image(s) for "
+                        "ComfyUI multi-ref generation"
+                    ),
+                    detail=(
+                        "Local face prequalification was skipped for this ComfyUI "
+                        "multi-reference image model; vision verification runs "
+                        "against the generated frame after image generation.\n"
+                        f"Identity ref qualification: {qualification_detail}"
+                    ),
+                    phase="keyframes",
+                    shot_index=shot.shot_index,
+                    kind="keyframe.identity_policy",
+                    source="identity_policy",
+                )
+            elif ref_image_bytes_list:
                 # HUMAN face refs are converted to face crops; non-human and wardrobe refs pass through.
                 try:
                     filtered_candidates, _prequalified_ref_embeddings_by_tag, policy_report = (
@@ -2362,6 +2697,14 @@ async def generate_keyframes(
                     )
                     if start_retry_guidance:
                         prompt_with_emphasis = f"{start_retry_guidance}\n\n{prompt_with_emphasis}"
+                    # ComfyUI reference-latent models treat refs as a weak hint;
+                    # the feature-anchored identity text measurably improves
+                    # likeness, so include it in the prompt for those branches.
+                    comfy_identity_prompt = (
+                        f"{prompt_with_emphasis}\n{identity_instr}"
+                        if identity_instr and _uses_comfyui_vision_primary(scene)
+                        else prompt_with_emphasis
+                    )
                     try:
                         if image_model == "qwen-image-edit-2509":
                             # Multi-ref edit model: compose start frame from
@@ -2372,7 +2715,7 @@ async def generate_keyframes(
                                 compose_prompt = (
                                     "Using the people, characters, and objects shown in the "
                                     "input images as exact identity references, create a new "
-                                    f"scene: {prompt_with_emphasis}"
+                                    f"scene: {comfy_identity_prompt}"
                                 )
                                 start_frame_bytes = await _generate_image_comfyui_qwen_edit_2509(
                                     comfy_client, compose_prompt, seed=base_seed,
@@ -2394,7 +2737,7 @@ async def generate_keyframes(
                             from vidpipe.services.comfyui_client import _FLUX2_RESOLUTIONS
                             f2w, f2h = _FLUX2_RESOLUTIONS.get(scene.aspect_ratio, (1024, 1024))
                             start_frame_bytes = await _generate_image_comfyui_flux2_klein(
-                                comfy_client, prompt_with_emphasis, seed=base_seed,
+                                comfy_client, comfy_identity_prompt, seed=base_seed,
                                 width=f2w, height=f2h,
                                 reference_image_bytes_list=attempt_ref_image_bytes[:4] or None,
                             )
@@ -2512,6 +2855,7 @@ async def generate_keyframes(
                     )
                     if should_verify:
                         verification_report = await _verify_generated_keyframe(
+                            session=session,
                             scene=scene,
                             shot=shot,
                             position="start",
@@ -2726,12 +3070,19 @@ async def generate_keyframes(
                     )
                     if end_retry_guidance:
                         prompt_with_emphasis = f"{end_retry_guidance}\n\n{prompt_with_emphasis}"
+                    # Feature-anchored identity text for ComfyUI reference models
+                    # (see start-frame block).
+                    comfy_identity_prompt = (
+                        f"{prompt_with_emphasis}\n{end_identity_instr}"
+                        if end_identity_instr and _uses_comfyui_vision_primary(scene)
+                        else prompt_with_emphasis
+                    )
                     try:
                         if image_model == "qwen-image-edit-2509":
                             # Multi-ref edit: image1 = start frame (drives output
                             # dimensions + visual conditioning), image2/3 = identity refs.
                             end_frame_bytes = await _generate_image_comfyui_qwen_edit_2509(
-                                comfy_client, prompt_with_emphasis,
+                                comfy_client, comfy_identity_prompt,
                                 seed=base_seed + shot.shot_index + 1000,
                                 image_bytes_list=[start_frame_bytes] + list(attempt_ref_image_bytes[:2]),
                             )
@@ -2741,7 +3092,7 @@ async def generate_keyframes(
                             from vidpipe.services.comfyui_client import _FLUX2_RESOLUTIONS as _F2R
                             ef2w, ef2h = _F2R.get(scene.aspect_ratio, (1024, 1024))
                             end_frame_bytes = await _generate_image_comfyui_flux2_klein(
-                                comfy_client, prompt_with_emphasis,
+                                comfy_client, comfy_identity_prompt,
                                 seed=base_seed + shot.shot_index + 1000,
                                 width=ef2w, height=ef2h,
                                 reference_image_bytes_list=(
@@ -2834,6 +3185,7 @@ async def generate_keyframes(
                     )
                     if should_verify:
                         verification_report = await _verify_generated_keyframe(
+                            session=session,
                             scene=scene,
                             shot=shot,
                             position="end",
@@ -2962,6 +3314,11 @@ async def generate_keyframes(
             await session.commit()
             raise
 
+    # Restore exact character identity via post-generation face swap (opt-in).
+    # Runs after all keyframes are generated/verified and before video generation
+    # so the swapped frames are what FLF2V/clip generation consumes.
+    await apply_scene_face_swaps(session, scene)
+
     # Update scene status after all keyframes generated
     scene.status = "generating_video"
     await session.commit()
@@ -2971,3 +3328,196 @@ async def generate_keyframes(
         phase="keyframes",
         message="Keyframe generation complete",
     )
+
+
+async def _resolve_primary_source_face(
+    session: AsyncSession,
+    scene: Scene,
+    shot: Shot,
+    file_mgr: FileManager,
+    svc,
+) -> tuple[Optional[bytes], Optional[str]]:
+    """Resolve the clearest real human face image to use as the swap source.
+
+    Looks at the shot's on-screen characters, resolves each to its bound actor
+    references, and returns the clearest real face for the first human character
+    that has a usable reference. Returns ``(None, None)`` when the shot has no
+    on-screen human character with a real reference (e.g. non-human characters,
+    synthetic-only refs, or no production bible) — the caller then skips the shot.
+
+    Resolution is derived purely from the DB (not the live generation loop's
+    in-memory state), so it works on resume.
+    """
+    if not scene.production_bible_id:
+        return None, None
+    tags = _ordered_unique_tags(normalize_json_list(shot.characters_present))
+    if not tags:
+        return None, None
+
+    from vidpipe.services.tag_resolver import (
+        canonicalize_character_tags,
+        resolve_tags_with_assets,
+    )
+
+    aliases = await canonicalize_character_tags(tags, scene.production_bible_id, session)
+    canonical_tags = _ordered_unique_tags([aliases.get(t, t) for t in tags])
+
+    for tag in canonical_tags:
+        resolved = await resolve_tags_with_assets(
+            f"@{tag}", scene.production_bible_id, session
+        )
+        for ref in resolved.asset_refs:
+            if ref.asset_type != "CHARACTER":
+                continue
+            if not _is_human_identity_type(getattr(ref, "identity_type", None)):
+                continue
+            # Prefer explicit face/identity refs; fall back to generic refs.
+            urls = list(getattr(ref, "face_reference_image_urls", []) or [])
+            if not urls:
+                urls = list(getattr(ref, "reference_image_urls", []) or [])
+            candidates: list[bytes] = []
+            for url in urls:
+                try:
+                    candidates.append(await file_mgr.read_bytes(url))
+                except Exception as e:  # noqa: BLE001
+                    logger.warning(
+                        "Face-swap: failed to read source ref %s — %s", url, e
+                    )
+            if not candidates:
+                continue
+            best = await asyncio.to_thread(svc.pick_clearest, candidates)
+            if best is not None:
+                return best, (_normalize_reference_tag(ref.tag) or tag)
+    return None, None
+
+
+async def apply_scene_face_swaps(session: AsyncSession, scene: Scene) -> None:
+    """Swap each on-screen character's real face onto the scene's keyframes.
+
+    Opt-in (``settings.face_swap.enabled``), idempotent, and resume-safe: each
+    keyframe is marked ``face_swapped`` and committed individually, so a crash
+    mid-pass resumes at the first un-swapped keyframe and re-runs never double
+    swap. The swapped image overwrites the keyframe in place (so video
+    generation transparently consumes it) and the pre-swap original is archived
+    as a ``_preswap`` sibling for threshold/restoration tuning.
+    """
+    if not settings.face_swap.enabled:
+        return
+
+    from vidpipe.services.face_restore_service import get_face_restore_service
+    from vidpipe.services.face_swap_service import get_face_swap_service
+
+    svc = get_face_swap_service()
+    if not await asyncio.to_thread(svc.available):
+        logger.warning(
+            "Face-swap enabled but service unavailable (inswapper model missing?); "
+            "leaving keyframes un-swapped for scene %s",
+            scene.id,
+        )
+        return
+
+    file_mgr = FileManager()
+    result = await session.execute(
+        select(Shot).where(Shot.scene_id == scene.id).order_by(Shot.shot_index)
+    )
+    shots = result.scalars().all()
+
+    # Cache resolved source face per identical character-tag set (avoids
+    # re-detecting the source ref for every shot sharing the same cast).
+    source_cache: dict[tuple, tuple[Optional[bytes], Optional[str]]] = {}
+    swapped_count = 0
+
+    for shot in shots:
+        cache_key = tuple(
+            _ordered_unique_tags(normalize_json_list(shot.characters_present))
+        )
+        if cache_key in source_cache:
+            source_png, source_tag = source_cache[cache_key]
+        else:
+            source_png, source_tag = await _resolve_primary_source_face(
+                session, scene, shot, file_mgr, svc
+            )
+            source_cache[cache_key] = (source_png, source_tag)
+        if source_png is None:
+            continue
+
+        kfs_result = await session.execute(
+            select(Keyframe).where(Keyframe.shot_id == shot.id)
+        )
+        for kf in kfs_result.scalars().all():
+            if kf.face_swapped:
+                continue
+            # Inherited start frames are byte-identical aliases of the previous
+            # shot's end frame — swap the shared pixels once on the owning row.
+            if kf.source == "inherited":
+                continue
+            try:
+                target_png = await file_mgr.read_bytes(kf.file_path)
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    "Face-swap: cannot read keyframe %s — %s", kf.file_path, e
+                )
+                continue
+
+            swapped, sim = await asyncio.to_thread(
+                svc.swap_face_with_score, target_png, source_png
+            )
+            if swapped is None:
+                # No detectable target face (e.g. stylised render) — keep the
+                # generated frame but mark done so we don't retry every resume.
+                kf.face_swapped = True
+                kf.verification_summary = (
+                    (kf.verification_summary or "") + " || face_swap=skipped_no_target_face"
+                )
+                await session.commit()
+                continue
+
+            # Post-swap quality: restore the soft 128px face (CodeFormer, GPU) so
+            # it matches the keyframe's native sharpness. This restored frame is
+            # what feeds video generation.
+            final_png = swapped
+            note = ""
+            if settings.face_swap.restore:
+                rsvc = get_face_restore_service()
+                if await asyncio.to_thread(rsvc.has_restore):
+                    restored = await asyncio.to_thread(
+                        rsvc.restore_primary_face, final_png
+                    )
+                    if restored is not None:
+                        final_png = restored
+                        note += f" restore=w{settings.face_swap.restore_weight}"
+
+            # Archive the pre-swap original (tuning/QA) then save the final
+            # (swapped + restored) keyframe in place.
+            await file_mgr.save_keyframe_async(
+                scene.id, shot.shot_index, f"{kf.position}_preswap", target_png
+            )
+            await file_mgr.save_keyframe_async(
+                scene.id, shot.shot_index, kf.position, final_png
+            )
+
+            # Optional: a separate 4K still artifact (does NOT feed video gen).
+            if settings.face_swap.upscale_keyframes:
+                rsvc = get_face_restore_service()
+                if await asyncio.to_thread(rsvc.has_upscale):
+                    up = await asyncio.to_thread(
+                        rsvc.upscale, final_png, settings.face_swap.upscale_scale
+                    )
+                    if up is not None:
+                        await file_mgr.save_keyframe_async(
+                            scene.id, shot.shot_index, f"{kf.position}_4k", up
+                        )
+                        note += f" upscale={settings.face_swap.upscale_scale}x"
+
+            kf.face_swapped = True
+            kf.verification_summary = (
+                (kf.verification_summary or "")
+                + f" || face_swap=ok src=@{source_tag} sim={sim:.3f}{note}"
+            )
+            await session.commit()
+            swapped_count += 1
+
+    if swapped_count:
+        logger.info(
+            "Face-swap: swapped %d keyframe(s) for scene %s", swapped_count, scene.id
+        )

--- a/backend/vidpipe/pipeline/stitcher.py
+++ b/backend/vidpipe/pipeline/stitcher.py
@@ -132,6 +132,7 @@ async def stitch_videos(session: AsyncSession, scene: Scene) -> None:
             scene.output_path = output_key
 
         scene.status = "complete"
+        scene.error_message = None  # clear stale errors from recovered runs
         logger.info(f"Scene {scene.id}: Stitching complete -> {scene.output_path}")
         await session.commit()
 

--- a/backend/vidpipe/pipeline/storyboard.py
+++ b/backend/vidpipe/pipeline/storyboard.py
@@ -234,8 +234,14 @@ VIDEO MOTION PROMPT FORMAT (video_motion_prompt):
 Describe ONLY motion and camera movement. Do NOT re-describe characters, setting, or style.
 The keyframe images already provide the visual context — the motion prompt controls what moves.
 Focus on: camera movement (pan, dolly, track, crane), subject animation, environmental animation.
-Good example: "Slow dolly forward as the subject turns to face the camera, hair gently blowing in the breeze"
+Good example: "Camera tracks alongside the subject as he strides forward through the crowd, pedestrians streaming past in both directions, rain streaking through neon light and steam billowing from vents"
 Bad example: "A blonde woman in anime style turns around in a congressional hearing room" (re-describes visuals)
+
+MOTION ENERGY (CRITICAL — the video model renders exactly the energy you describe):
+Every video_motion_prompt MUST describe continuous, clearly visible motion that is already in progress at the first frame. Combine at least two of: subject action (walking, turning, reaching, gesturing), environmental animation (crowd movement, rain, steam, flickering signs, traffic), and camera movement (tracking, dolly, pan).
+- The video models take motion language literally. Words like "slowly", "static", "still", "subtle", "gentle", "steady", "motionless" produce frozen, lifeless clips — DO NOT use them, especially never for a scene's opening shot.
+- Prefer active, present-tense verbs: "strides", "tracks", "sweeps", "rushes", "turns sharply", "pushes through".
+- A held emotional beat can still have motion: keep the camera or environment moving even when the subject is relatively still (e.g. "the subject holds his position as the camera slowly circles and rain pours around him" — circling + rain still reads as alive).
 
 FRAMING-MOTION SAFETY:
 Camera movement must be compatible with subject positioning in the start keyframe.
@@ -243,9 +249,8 @@ Camera movement must be compatible with subject positioning in the start keyfram
 - If camera PANS DOWN or TILTS DOWN: position the subject in the UPPER half of the start keyframe
 - If camera DOLLIES IN: ensure subject face is clearly visible and centered in start keyframe
 - NEVER generate motion that would push the primary subject's head out of frame
-- PREFER subtle camera movements (slow dolly, gentle tracking) over dramatic pans/tilts
-  when the subject must remain recognizable throughout
-- When in doubt, use a STATIC or SLOW DOLLY camera — these preserve character identity best
+- To keep the subject recognizable during strong motion, use TRACKING or ORBITING camera moves
+  (which follow the subject) rather than fully static framing — motion and identity are NOT in conflict
 
 GOAL: Ensure all shots maintain visual coherence in {style} style while telling a compelling story. Preserve the original script's specific terminology, names, and details — do not reduce domain-specific content to generic visual metaphors."""
 
@@ -1175,8 +1180,14 @@ VIDEO MOTION PROMPT FORMAT (video_motion_prompt):
 Describe ONLY motion and camera movement. Do NOT re-describe characters, setting, or style.
 The keyframe images already provide the visual context — the motion prompt controls what moves.
 Focus on: camera movement (pan, dolly, track, crane), subject animation, environmental animation.
-Good example: "Slow dolly forward as the subject turns to face the camera, hair gently blowing in the breeze"
+Good example: "Camera tracks alongside the subject as he strides forward through the crowd, pedestrians streaming past in both directions, rain streaking through neon light and steam billowing from vents"
 Bad example: "A blonde woman in anime style turns around in a congressional hearing room" (re-describes visuals)
+
+MOTION ENERGY (CRITICAL — the video model renders exactly the energy you describe):
+Every video_motion_prompt MUST describe continuous, clearly visible motion that is already in progress at the first frame. Combine at least two of: subject action (walking, turning, reaching, gesturing), environmental animation (crowd movement, rain, steam, flickering signs, traffic), and camera movement (tracking, dolly, pan).
+- The video models take motion language literally. Words like "slowly", "static", "still", "subtle", "gentle", "steady", "motionless" produce frozen, lifeless clips — DO NOT use them, especially never for a scene's opening shot.
+- Prefer active, present-tense verbs: "strides", "tracks", "sweeps", "rushes", "turns sharply", "pushes through".
+- A held emotional beat can still have motion: keep the camera or environment moving even when the subject is relatively still (e.g. "the subject holds his position as the camera slowly circles and rain pours around him" — circling + rain still reads as alive).
 
 FRAMING-MOTION SAFETY:
 Camera movement must be compatible with subject positioning in the start keyframe.
@@ -1184,9 +1195,8 @@ Camera movement must be compatible with subject positioning in the start keyfram
 - If camera PANS DOWN or TILTS DOWN: position the subject in the UPPER half of the start keyframe
 - If camera DOLLIES IN: ensure subject face is clearly visible and centered in start keyframe
 - NEVER generate motion that would push the primary subject's head out of frame
-- PREFER subtle camera movements (slow dolly, gentle tracking) over dramatic pans/tilts
-  when the subject must remain recognizable throughout
-- When in doubt, use a STATIC or SLOW DOLLY camera — these preserve character identity best
+- To keep the subject recognizable during strong motion, use TRACKING or ORBITING camera moves
+  (which follow the subject) rather than fully static framing — motion and identity are NOT in conflict
 
 GOAL: Ensure all shots maintain visual coherence in {style} style while telling a compelling story. Preserve the original script's specific terminology, names, and details — do not reduce domain-specific content to generic visual metaphors."""
 

--- a/backend/vidpipe/pipeline/video_gen.py
+++ b/backend/vidpipe/pipeline/video_gen.py
@@ -21,6 +21,7 @@ Usage:
 
 import asyncio
 import logging
+import time
 from pathlib import Path
 from typing import Optional
 
@@ -38,12 +39,12 @@ from tenacity import (
 )
 
 from vidpipe.config import settings
-from vidpipe.db.models import Scene, Shot, Keyframe, VideoClip, GenerationCandidate
+from vidpipe.db.models import DEFAULT_USER_ID, Scene, Shot, Keyframe, UserSettings, VideoClip, GenerationCandidate
 from vidpipe.services.candidate_scoring import CandidateScoringService
 from vidpipe.services.cv_analysis_service import CVAnalysisService
 from vidpipe.services.entity_extraction import identify_new_entities, extract_and_register_new_entities
 from vidpipe.services.file_manager import FileManager
-from vidpipe.services.llm import LLMAdapter
+from vidpipe.services.llm import LLMAdapter, get_adapter
 from vidpipe.services.vertex_client import get_vertex_client, location_for_model
 from vidpipe.services.model_catalog import canonical_model_id
 from vidpipe.services import manifest_service
@@ -599,6 +600,7 @@ async def _handle_quality_mode_candidates(
     has_refs: bool = False,
     scoring_service: Optional[CandidateScoringService] = None,
     cv_service: Optional[CVAnalysisService] = None,
+    vision_adapter: Optional[LLMAdapter] = None,
 ) -> None:
     """Save all candidate videos, score them, and auto-select the best one.
 
@@ -707,7 +709,14 @@ async def _handle_quality_mode_candidates(
 
     # Step 8: Run CV analysis on selected candidate only
     await _run_post_generation_analysis(
-        session, shot, clip, scene, shot_manifest_row, file_mgr, cv_service=cv_service
+        session,
+        shot,
+        clip,
+        scene,
+        shot_manifest_row,
+        file_mgr,
+        cv_service=cv_service,
+        vision_adapter=vision_adapter,
     )
 
 
@@ -722,6 +731,7 @@ async def _run_post_generation_analysis(
     shot_manifest_row,  # ShotManifest | None (imported inline to avoid circular)
     file_mgr: FileManager,
     cv_service: Optional[CVAnalysisService] = None,
+    vision_adapter: Optional[LLMAdapter] = None,
 ) -> None:
     """Run CV analysis on completed video clip for progressive enrichment.
 
@@ -787,6 +797,7 @@ async def _run_post_generation_analysis(
                     shot_manifest_row.manifest_json if shot_manifest_row else None
                 ),
                 existing_assets=all_assets,
+                vision_adapter=vision_adapter,
             )
 
             # Step 6: Track appearances — persist AssetAppearance records
@@ -804,6 +815,7 @@ async def _run_post_generation_analysis(
                     shot.shot_index,
                     new_entities,
                     source="CLIP_EXTRACT",
+                    vision_adapter=vision_adapter,
                 )
 
             # Step 8: Persist analysis results to ShotManifest (exclude raw embeddings)
@@ -856,6 +868,14 @@ async def generate_videos(
     is_comfyui = video_model in COMFYUI_VIDEO_MODELS
     client = None if is_comfyui else get_vertex_client(location=location_for_model(video_model))
     file_mgr = FileManager()
+
+    if vision_adapter is None:
+        user_settings_result = await session.execute(
+            select(UserSettings).where(UserSettings.user_id == DEFAULT_USER_ID)
+        )
+        user_settings = user_settings_result.scalar_one_or_none()
+        vision_model_id = scene.vision_model or scene.text_model or settings.models.storyboard_llm
+        vision_adapter = get_adapter(vision_model_id, user_settings=user_settings)
 
     # Instantiate per-call services with vision_adapter instead of adapter-unaware singletons
     cv_service = CVAnalysisService(vision_adapter=vision_adapter)
@@ -917,7 +937,13 @@ async def generate_videos(
         try:
             if is_comfyui:
                 await _generate_video_comfyui(
-                    session, shot, file_mgr, scene, video_model,
+                    session,
+                    shot,
+                    file_mgr,
+                    scene,
+                    video_model,
+                    cv_service=cv_service,
+                    vision_adapter=vision_adapter,
                 )
             else:
                 await _generate_video_for_shot(
@@ -925,6 +951,7 @@ async def generate_videos(
                     cv_service=cv_service,
                     scoring_service=scoring_service,
                     text_adapter=text_adapter,
+                    vision_adapter=vision_adapter,
                 )
 
             # Clear generation_status after successful generation (VGED-05)
@@ -943,6 +970,35 @@ async def generate_videos(
             await session.commit()
             event_bus.emit(scene.id, "error", phase="clips", shot_index=shot.shot_index, message=str(e))
             raise
+
+    # No silent partial scenes: every shot must have reached video_done
+    # before stitching. A timed-out/failed shot used to fall through here
+    # and the stitcher would happily stitch the remaining clips, marking a
+    # truncated scene "complete".
+    result = await session.execute(
+        select(Shot)
+        .where(Shot.scene_id == scene.id)
+        .order_by(Shot.shot_index)
+    )
+    all_shots = result.scalars().all()
+    incomplete = [s for s in all_shots if s.status != "video_done"]
+    if incomplete:
+        details = []
+        for s in incomplete:
+            clip_result = await session.execute(
+                select(VideoClip).where(VideoClip.shot_id == s.id)
+            )
+            failed_clip = clip_result.scalar_one_or_none()
+            reason = (
+                failed_clip.error_message
+                if failed_clip and failed_clip.error_message
+                else s.status
+            )
+            details.append(f"shot {s.shot_index}: {reason}")
+        raise RuntimeError(
+            f"Video generation incomplete for {len(incomplete)} of "
+            f"{len(all_shots)} shot(s) — " + "; ".join(details)
+        )
 
     # Update scene status
     scene.status = "stitching"
@@ -964,6 +1020,8 @@ async def _generate_video_comfyui(
     file_mgr: FileManager,
     scene: Scene,
     video_model: str,
+    cv_service: Optional[CVAnalysisService] = None,
+    vision_adapter: Optional[LLMAdapter] = None,
 ) -> None:
     """Generate video clip for a single shot via ComfyUI Cloud.
 
@@ -1042,6 +1100,33 @@ async def _generate_video_comfyui(
     comfy_client = await get_comfyui_client(host=comfy_host, api_key=comfy_key)
     adapter = ComfyUIVideoAdapter(comfy_client)
 
+    # Load character reference images (if manifest scene). Wired as QC
+    # passthroughs on models with supports_char_refs (wan-2.2-flf2v).
+    # Loaded up-front so corrupted-clip retries can resubmit.
+    char_ref_bytes: list[bytes] = []
+    if scene.production_bible_id:
+        char_ref_bytes = await _load_char_ref_images(session, scene)
+
+    async def _submit_fresh(attempt: int, *, prompt_override: str | None = None) -> str:
+        """Submit a new ComfyUI job. ``attempt`` perturbs the seed so a retry
+        cannot hit ComfyUI's node cache and receive the same corrupted encode.
+        ``prompt_override`` replaces the motion prompt (used by motion escalation).
+        """
+        # Framing-safety prompt prefix is applied per-model by the adapter
+        # (COMFY_VIDEO_SPECS.prompt_prefix).
+        return await adapter.submit(
+            video_prompt=prompt_override or video_prompt,
+            start_frame_bytes=start_frame_bytes,
+            end_frame_bytes=end_frame_bytes,
+            char_ref_bytes=char_ref_bytes,
+            aspect_ratio=scene.aspect_ratio,
+            seed=(scene.seed or 0) + attempt * 1000003,
+            shot_index=shot.shot_index,
+            video_model=video_model,
+            duration_seconds=scene.target_clip_duration or 5,
+            audio_enabled=bool(scene.audio_enabled),
+        )
+
     # If clip exists with comfyui: prefix and is polling, resume poll
     if clip and clip.status == "polling" and clip.operation_name and clip.operation_name.startswith("comfyui:"):
         logger.info(
@@ -1051,27 +1136,7 @@ async def _generate_video_comfyui(
     else:
         # Fresh submission via adapter
         logger.info("Shot %d: submitting to ComfyUI", shot.shot_index)
-
-        # Load character reference images (if manifest scene). Wired as QC
-        # passthroughs on models with supports_char_refs (wan-2.2-flf2v).
-        char_ref_bytes: list[bytes] = []
-        if scene.production_bible_id:
-            char_ref_bytes = await _load_char_ref_images(session, scene)
-
-        # Framing-safety prompt prefix is applied per-model by the adapter
-        # (COMFY_VIDEO_SPECS.prompt_prefix).
-        operation_id = await adapter.submit(
-            video_prompt=video_prompt,
-            start_frame_bytes=start_frame_bytes,
-            end_frame_bytes=end_frame_bytes,
-            char_ref_bytes=char_ref_bytes,
-            aspect_ratio=scene.aspect_ratio,
-            seed=scene.seed or 0,
-            shot_index=shot.shot_index,
-            video_model=video_model,
-            duration_seconds=scene.target_clip_duration or 5,
-            audio_enabled=bool(scene.audio_enabled),
-        )
+        operation_id = await _submit_fresh(0)
 
         # Create/update clip record (persist before polling for crash recovery)
         if clip is None:
@@ -1095,72 +1160,237 @@ async def _generate_video_comfyui(
     # --- Poll loop (adapter normalizes status to "completed"/"failed"/"running") ---
     poll_interval = settings.pipeline.video_poll_interval
     max_polls = settings.pipeline.video_poll_max
+    max_corrupt_retries = (
+        settings.pipeline.clip_corrupt_retry_max
+        if settings.pipeline.clip_validation_enabled
+        else 0
+    )
+    max_motion_retries = (
+        settings.pipeline.clip_motion_retry_max
+        if settings.pipeline.clip_validation_enabled
+        else 0
+    )
+    corruption_attempt = 0
+    motion_attempt = 0
 
-    for poll_attempt in range(clip.poll_count, max_polls):
-        status, error_msg = await adapter.poll(clip.operation_name)
-        clip.poll_count = poll_attempt + 1
+    while True:
+        video_bytes = None
+        duration = None
 
-        if status == "completed":
-            # Download via adapter (handles history parsing + download)
-            try:
-                video_bytes, duration = await adapter.download(
-                    clip.operation_name,
-                    video_model=video_model,
-                    duration_seconds=scene.target_clip_duration or 5,
-                )
-            except Exception as e:
+        queue_deadline = time.monotonic() + settings.pipeline.comfy_queue_timeout
+
+        while True:
+            status, error_msg = await adapter.poll(clip.operation_name)
+
+            if status == "completed":
+                # Download via adapter (handles history parsing + download)
+                try:
+                    video_bytes, duration = await adapter.download(
+                        clip.operation_name,
+                        video_model=video_model,
+                        duration_seconds=scene.target_clip_duration or 5,
+                    )
+                except Exception as e:
+                    clip.status = "failed"
+                    clip.error_message = f"Video download failed: {e}"
+                    shot.status = "failed"
+                    await session.commit()
+                    logger.error("Shot %d: ComfyUI download failed: %s", shot.shot_index, e)
+                    return
+                break
+
+            elif status == "failed":
                 clip.status = "failed"
-                clip.error_message = f"Video download failed: {e}"
+                clip.error_message = error_msg or "ComfyUI job failed"
                 shot.status = "failed"
                 await session.commit()
-                logger.error("Shot %d: ComfyUI download failed: %s", shot.shot_index, e)
+                logger.error("Shot %d: ComfyUI job failed: %s", shot.shot_index, error_msg)
                 return
 
-            # Save clip
-            clip_stored_path = await file_mgr.save_clip_async(
-                scene.id, shot.shot_index, video_bytes,
-            )
-            clip.local_path = clip_stored_path
-            clip.status = "complete"
-            clip.duration_seconds = duration
-            clip.source = "generated"
-            shot.status = "video_done"
+            elif status == "queued":
+                # Held under Comfy Cloud concurrency limits ("queued_limited")
+                # — queue time does not consume the execution poll budget.
+                if time.monotonic() > queue_deadline:
+                    clip.status = "timed_out"
+                    clip.error_message = (
+                        f"ComfyUI job stayed queued for more than "
+                        f"{settings.pipeline.comfy_queue_timeout} seconds"
+                    )
+                    shot.status = "timed_out"
+                    await session.commit()
+                    logger.error("Shot %d: ComfyUI queue wait timed out", shot.shot_index)
+                    return
+
+            else:
+                # Executing — consume execution poll budget
+                clip.poll_count += 1
+                if clip.poll_count >= max_polls:
+                    clip.status = "timed_out"
+                    clip.error_message = (
+                        f"ComfyUI operation did not complete after "
+                        f"{max_polls * poll_interval} seconds of execution"
+                    )
+                    shot.status = "timed_out"
+                    await session.commit()
+                    logger.error("Shot %d: ComfyUI poll timed out", shot.shot_index)
+                    return
+
+            # Still waiting — sleep and continue
             await session.commit()
+            await asyncio.sleep(poll_interval)
 
-            # Post-generation CV analysis (reuse existing)
-            await _run_post_generation_analysis(
-                session, shot, clip, scene, shot_manifest_row, file_mgr,
+            # Check for user-requested stop
+            await session.refresh(scene)
+            if scene.status == "stopped":
+                from vidpipe.orchestrator.pipeline import PipelineStopped
+                raise PipelineStopped("Pipeline stopped by user")
+
+        # Degenerate-clip gate: ComfyUI Cloud has returned corrupted MP4s on
+        # jobs that report success (noise frames between the conditioning
+        # frames). Validate before accepting; resubmit with a perturbed seed
+        # on failure so the corrupted encode cannot be served from cache.
+        if settings.pipeline.clip_validation_enabled:
+            from vidpipe.services.clip_validation import validate_clip_integrity
+
+            validation = await asyncio.to_thread(
+                validate_clip_integrity,
+                video_bytes,
+                start_frame_bytes=start_frame_bytes,
+                end_frame_bytes=end_frame_bytes,
+            )
+            if not validation.ok:
+                logger.warning(
+                    "Shot %d: downloaded clip failed integrity check (%s) — "
+                    "attempt %d of %d",
+                    shot.shot_index, validation.detail,
+                    corruption_attempt + 1, max_corrupt_retries + 1,
+                )
+                if corruption_attempt < max_corrupt_retries:
+                    corruption_attempt += 1
+                    from vidpipe.services.event_bus import emit_task_log
+
+                    emit_task_log(
+                        scene.id,
+                        summary=(
+                            f"Shot {shot.shot_index + 1}: corrupted clip from "
+                            f"ComfyUI — regenerating (retry {corruption_attempt})"
+                        ),
+                        detail=validation.detail,
+                        phase="clips",
+                        shot_index=shot.shot_index,
+                        kind="clip.corrupted_retry",
+                        source="clip_validation",
+                    )
+                    clip.operation_name = await _submit_fresh(corruption_attempt)
+                    clip.status = "polling"
+                    clip.poll_count = 0
+                    clip.error_message = None
+                    await session.commit()
+                    continue
+
+                clip.status = "failed"
+                clip.error_message = (
+                    f"Corrupted video from ComfyUI after "
+                    f"{corruption_attempt + 1} attempt(s): {validation.detail}"
+                )
+                shot.status = "failed"
+                await session.commit()
+                raise RuntimeError(
+                    f"Shot {shot.shot_index}: {clip.error_message}"
+                )
+            logger.info(
+                "Shot %d: clip integrity OK (%s)", shot.shot_index, validation.detail,
             )
 
-            logger.info("Shot %d: ComfyUI video complete", shot.shot_index)
-            return
+            # Motion gate: LTX/ComfyUI FLF2V can render a near-static clip when
+            # the storyboard motion prompt uses freeze language ("slowly",
+            # "steady", "remains static"). Escalate the prompt and resubmit.
+            if validation.motion_mean < settings.pipeline.clip_min_motion:
+                from vidpipe.services.event_bus import emit_task_log
 
-        elif status == "failed":
-            clip.status = "failed"
-            clip.error_message = error_msg or "ComfyUI job failed"
-            shot.status = "failed"
-            await session.commit()
-            logger.error("Shot %d: ComfyUI job failed: %s", shot.shot_index, error_msg)
-            return
+                if motion_attempt < max_motion_retries:
+                    motion_attempt += 1
+                    from vidpipe.services.comfyui_adapter import escalate_motion_prompt
 
-        # Still running — sleep and continue
+                    escalated = escalate_motion_prompt(video_prompt)
+                    logger.warning(
+                        "Shot %d: clip near-static (motion=%.2f < %.1f) — "
+                        "regenerating with motion-amplified prompt (retry %d of %d)",
+                        shot.shot_index, validation.motion_mean,
+                        settings.pipeline.clip_min_motion,
+                        motion_attempt, max_motion_retries,
+                    )
+                    emit_task_log(
+                        scene.id,
+                        summary=(
+                            f"Shot {shot.shot_index + 1}: near-static clip "
+                            f"(motion {validation.motion_mean:.1f}) — regenerating "
+                            f"with stronger motion (retry {motion_attempt})"
+                        ),
+                        detail=validation.detail,
+                        phase="clips",
+                        shot_index=shot.shot_index,
+                        kind="clip.low_motion_retry",
+                        source="clip_validation",
+                    )
+                    # Motion attempts use a distinct seed-salt range (100+) so
+                    # they never collide with corruption-retry seeds.
+                    clip.operation_name = await _submit_fresh(
+                        100 + motion_attempt, prompt_override=escalated
+                    )
+                    clip.status = "polling"
+                    clip.poll_count = 0
+                    clip.error_message = None
+                    await session.commit()
+                    continue
+
+                # Retries exhausted (or disabled) — accept with a warning rather
+                # than fail the scene; a static clip is usable, just not ideal.
+                logger.warning(
+                    "Shot %d: accepting near-static clip (motion=%.2f) after "
+                    "%d motion retry(ies)",
+                    shot.shot_index, validation.motion_mean, motion_attempt,
+                )
+                if max_motion_retries > 0:
+                    emit_task_log(
+                        scene.id,
+                        summary=(
+                            f"Shot {shot.shot_index + 1}: clip still low-motion "
+                            f"(motion {validation.motion_mean:.1f}) — accepted with warning"
+                        ),
+                        detail=validation.detail,
+                        phase="clips",
+                        shot_index=shot.shot_index,
+                        kind="clip.low_motion_accepted",
+                        source="clip_validation",
+                        level="warning",
+                    )
+
+        # Save clip
+        clip_stored_path = await file_mgr.save_clip_async(
+            scene.id, shot.shot_index, video_bytes,
+        )
+        clip.local_path = clip_stored_path
+        clip.status = "complete"
+        clip.duration_seconds = duration
+        clip.source = "generated"
+        shot.status = "video_done"
         await session.commit()
-        await asyncio.sleep(poll_interval)
 
-        # Check for user-requested stop
-        await session.refresh(scene)
-        if scene.status == "stopped":
-            from vidpipe.orchestrator.pipeline import PipelineStopped
-            raise PipelineStopped("Pipeline stopped by user")
+        # Post-generation CV analysis (reuse existing)
+        await _run_post_generation_analysis(
+            session,
+            shot,
+            clip,
+            scene,
+            shot_manifest_row,
+            file_mgr,
+            cv_service=cv_service,
+            vision_adapter=vision_adapter,
+        )
 
-    # Timed out
-    clip.status = "timed_out"
-    clip.error_message = (
-        f"ComfyUI operation did not complete after {max_polls * poll_interval} seconds"
-    )
-    shot.status = "timed_out"
-    await session.commit()
-    logger.error("Shot %d: ComfyUI poll timed out", shot.shot_index)
+        logger.info("Shot %d: ComfyUI video complete", shot.shot_index)
+        return
 
 
 async def _load_char_ref_images(
@@ -1248,6 +1478,7 @@ async def _generate_video_for_shot(
     cv_service: Optional[CVAnalysisService] = None,
     scoring_service: Optional[CandidateScoringService] = None,
     text_adapter: Optional[LLMAdapter] = None,
+    vision_adapter: Optional[LLMAdapter] = None,
 ) -> None:
     """Generate video clip for a single shot with escalating content-policy
     remediation and transient-error retry.
@@ -1447,6 +1678,7 @@ async def _generate_video_for_shot(
                     has_refs=bool(selected_refs),
                     scoring_service=scoring_service,
                     cv_service=cv_service,
+                    vision_adapter=vision_adapter,
                 )
                 return
             elif poll_result != "content_policy":
@@ -1465,7 +1697,14 @@ async def _generate_video_for_shot(
                 if poll_result == "complete":
                     # Phase 9: Post-generation CV analysis for progressive enrichment
                     await _run_post_generation_analysis(
-                        session, shot, clip, scene, shot_manifest_row, file_mgr, cv_service=cv_service,
+                        session,
+                        shot,
+                        clip,
+                        scene,
+                        shot_manifest_row,
+                        file_mgr,
+                        cv_service=cv_service,
+                        vision_adapter=vision_adapter,
                     )
                 return  # complete, failed, or timed_out
             # Content policy → fall through to escalation loop
@@ -1640,11 +1879,19 @@ async def _generate_video_for_shot(
                         has_refs=bool(veo_ref_images),
                         scoring_service=scoring_service,
                         cv_service=cv_service,
+                        vision_adapter=vision_adapter,
                     )
                 else:
                     # Standard mode: Phase 9 post-generation CV analysis
                     await _run_post_generation_analysis(
-                        session, shot, clip, scene, shot_manifest_row, file_mgr, cv_service=cv_service,
+                        session,
+                        shot,
+                        clip,
+                        scene,
+                        shot_manifest_row,
+                        file_mgr,
+                        cv_service=cv_service,
+                        vision_adapter=vision_adapter,
                     )
                 return
             elif poll_result == "content_policy":

--- a/backend/vidpipe/pipeline/video_gen.py
+++ b/backend/vidpipe/pipeline/video_gen.py
@@ -49,9 +49,16 @@ from vidpipe.services.model_catalog import canonical_model_id
 from vidpipe.services import manifest_service
 
 # ---------------------------------------------------------------------------
-# ComfyUI model IDs (routed to ComfyUI instead of Veo)
+# ComfyUI model IDs (routed to ComfyUI instead of Veo).
+# Per-model behavior (fps, end-frame/audio support, workflow builder) lives in
+# COMFY_VIDEO_SPECS in services/comfyui_adapter.py — keep both in sync.
 # ---------------------------------------------------------------------------
-COMFYUI_VIDEO_MODELS = {"wan-2.2-i2v"}
+COMFYUI_VIDEO_MODELS = {
+    "wan-2.2-i2v",
+    "wan-2.2-flf2v",
+    "ltx-2.3-flf2v",
+    "seedance-2.0-flf2v",
+}
 
 
 logger = logging.getLogger(__name__)
@@ -973,9 +980,13 @@ async def _generate_video_comfyui(
     from vidpipe.services.comfyui_client import get_comfyui_client
     from vidpipe.services.comfyui_adapter import ComfyUIVideoAdapter
 
-    is_i2v = video_model == "wan-2.2-i2v"
+    from vidpipe.services.comfyui_adapter import COMFY_VIDEO_SPECS
 
-    # Load keyframes
+    spec = COMFY_VIDEO_SPECS.get(video_model)
+
+    # Load keyframes. Start is always required; a missing end keyframe on an
+    # FLF2V-capable model is a soft degrade (the adapter falls back to
+    # first-frame-only generation), not an error.
     kf_result = await session.execute(
         select(Keyframe)
         .where(Keyframe.shot_id == shot.id)
@@ -984,18 +995,16 @@ async def _generate_video_comfyui(
     keyframes = kf_result.scalars().all()
     start_kf = next((k for k in keyframes if k.position == "start"), None)
     end_kf = next((k for k in keyframes if k.position == "end"), None)
-    if is_i2v:
-        if start_kf is None:
-            raise ValueError(
-                f"Shot {shot.shot_index} missing start keyframe — cannot generate video"
-            )
-    else:
-        if start_kf is None or end_kf is None:
-            missing = [p for p, kf in [("start", start_kf), ("end", end_kf)] if kf is None]
-            raise ValueError(
-                f"Shot {shot.shot_index} missing {' and '.join(missing)} "
-                f"keyframe(s) — cannot generate video"
-            )
+    if start_kf is None:
+        raise ValueError(
+            f"Shot {shot.shot_index} missing start keyframe — cannot generate video"
+        )
+    if end_kf is None and spec is not None and spec.supports_end_frame:
+        logger.warning(
+            "Shot %d: %s supports end-frame conditioning but no end keyframe "
+            "exists — degrading to first-frame-only generation",
+            shot.shot_index, video_model,
+        )
 
     start_frame_bytes = await file_mgr.read_bytes(start_kf.file_path)
     end_frame_bytes = await file_mgr.read_bytes(end_kf.file_path) if end_kf else None
@@ -1043,20 +1052,14 @@ async def _generate_video_comfyui(
         # Fresh submission via adapter
         logger.info("Shot %d: submitting to ComfyUI", shot.shot_index)
 
-        # Load character reference images (if manifest scene)
-        # TODO: char_ref_bytes loaded but not yet wired into WAN 2.2 I2V workflow.
-        # See docs/camera-pan.md Action 3 for the plan to add ref image support.
+        # Load character reference images (if manifest scene). Wired as QC
+        # passthroughs on models with supports_char_refs (wan-2.2-flf2v).
         char_ref_bytes: list[bytes] = []
         if scene.production_bible_id:
             char_ref_bytes = await _load_char_ref_images(session, scene)
 
-        # WAN I2V has no reference images — prepend framing safety to motion prompt
-        video_prompt = (
-            "Keep the subject's face and full head visible in frame throughout the entire clip. "
-            "Maintain consistent character appearance and proportions. "
-            + video_prompt
-        )
-
+        # Framing-safety prompt prefix is applied per-model by the adapter
+        # (COMFY_VIDEO_SPECS.prompt_prefix).
         operation_id = await adapter.submit(
             video_prompt=video_prompt,
             start_frame_bytes=start_frame_bytes,
@@ -1066,6 +1069,8 @@ async def _generate_video_comfyui(
             seed=scene.seed or 0,
             shot_index=shot.shot_index,
             video_model=video_model,
+            duration_seconds=scene.target_clip_duration or 5,
+            audio_enabled=bool(scene.audio_enabled),
         )
 
         # Create/update clip record (persist before polling for crash recovery)
@@ -1098,7 +1103,11 @@ async def _generate_video_comfyui(
         if status == "completed":
             # Download via adapter (handles history parsing + download)
             try:
-                video_bytes, duration = await adapter.download(clip.operation_name)
+                video_bytes, duration = await adapter.download(
+                    clip.operation_name,
+                    video_model=video_model,
+                    duration_seconds=scene.target_clip_duration or 5,
+                )
             except Exception as e:
                 clip.status = "failed"
                 clip.error_message = f"Video download failed: {e}"

--- a/backend/vidpipe/qa/__init__.py
+++ b/backend/vidpipe/qa/__init__.py
@@ -1,0 +1,16 @@
+"""Adversarial video-QA harness.
+
+Audits a finished production against quality criteria the generation pipeline
+itself does not hard-gate: character identity alignment to the Production Bible,
+story/scene alignment, and audio integrity (corruption, garble, clipping,
+dropouts). Produces a scored PASS/FAIL report and is wired into a pytest gate.
+
+Run:
+    python -m vidpipe.qa.audit <production_id> [--out DIR] [--no-embeddings]
+
+The vision judge uses the production's *selected* vision LLM (Gemini or Ollama)
+via ``vidpipe.services.llm.registry.get_adapter`` — it is not hard-coded to any
+provider. A face-embedding (InsightFace) check runs alongside it when available.
+"""
+
+from vidpipe.qa.criteria import Finding, Severity, Verdict  # noqa: F401

--- a/backend/vidpipe/qa/audio.py
+++ b/backend/vidpipe/qa/audio.py
@@ -1,0 +1,170 @@
+"""FFmpeg-based audio-integrity analysis.
+
+Detects the failure modes the pipeline does not gate: garbled/broadband-noise
+audio (e.g. LTX native-audio babble), digital clipping, mid-shot dropouts, and
+DC offset. Spectral flatness is the primary garble signal — tonal speech/music
+sits low (~0.1-0.3); white-noise garble pushes toward 1.0.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from typing import Optional
+
+from vidpipe.qa import criteria as C
+from vidpipe.qa.criteria import Finding, Severity
+
+
+@dataclass
+class AudioMetrics:
+    label: str
+    has_audio: bool
+    duration: float = 0.0
+    mean_db: Optional[float] = None
+    max_db: Optional[float] = None
+    peak_db: Optional[float] = None
+    flat_factor: Optional[float] = None
+    dc_offset: Optional[float] = None
+    spectral_flatness: Optional[float] = None      # mean over the whole segment, 0..1
+    flatness_median: Optional[float] = None        # median of 2s-window means
+    garble_windows: list[dict] = None              # outlier windows: {start,end,mean,max}
+    mid_dropout_s: float = 0.0                       # longest silence gap not at the edges
+
+    def as_dict(self) -> dict:
+        d = self.__dict__.copy()
+        return d
+
+
+def _run(cmd: list[str]) -> str:
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    return (p.stderr or "") + (p.stdout or "")
+
+
+def _f(pattern: str, text: str) -> Optional[float]:
+    m = re.search(pattern, text)
+    return float(m.group(1)) if m else None
+
+
+def probe_has_audio(path: str) -> bool:
+    out = _run(["ffprobe", "-v", "error", "-select_streams", "a:0",
+                "-show_entries", "stream=codec_type", "-of", "csv=p=0", path])
+    return "audio" in out
+
+
+def _flatness_windows(path: str, win: float = 2.0) -> tuple[Optional[float], Optional[float], list[dict]]:
+    """Per-window spectral flatness via aspectralstats metadata.
+
+    Returns (overall_mean, median_of_window_means, garble_windows). Garble is
+    detected as a window that is an OUTLIER vs the track's own median (robust to
+    naturally noisy beds), with an absolute floor — tonal speech sits ~0.05-0.15,
+    broadband-noise garble spikes toward 1.0.
+    """
+    out = _run(["ffmpeg", "-hide_banner", "-nostats", "-i", path,
+                "-af", "aspectralstats=measure=flatness,ametadata=print:file=-",
+                "-f", "null", "-"])
+    t = None
+    buckets: dict[int, list[float]] = {}
+    allvals: list[float] = []
+    for line in out.splitlines():
+        mt = re.search(r"pts_time:([0-9.]+)", line)
+        if mt:
+            t = float(mt.group(1))
+        mf = re.search(r"flatness=([0-9.eE+-]+)", line)
+        if mf and t is not None:
+            v = float(mf.group(1))
+            allvals.append(v)
+            buckets.setdefault(int(t // win * win), []).append(v)
+    if not allvals:
+        return None, None, []
+    overall = sum(allvals) / len(allvals)
+    win_means = {s: sum(v) / len(v) for s, v in buckets.items()}
+    ordered = sorted(win_means.values())
+    median = ordered[len(ordered) // 2]
+    garble = []
+    for s in sorted(buckets):
+        wm = win_means[s]
+        wmax = max(buckets[s])
+        # Outlier vs own median AND absolute floor AND a genuinely noisy peak.
+        if wm >= max(C.AUDIO_SPECTRAL_FLATNESS_MAX * 0.4, 2.5 * median) and wmax >= 0.5:
+            garble.append({"start": float(s), "end": float(s + win),
+                           "mean": round(wm, 3), "max": round(wmax, 3)})
+    return overall, median, garble
+
+
+def analyze(path: str, label: str) -> AudioMetrics:
+    if not probe_has_audio(path):
+        return AudioMetrics(label=label, has_audio=False)
+    dur = _f(r"Duration: (\d+):(\d+):", "") or 0.0
+    durtxt = _run(["ffprobe", "-v", "error", "-show_entries", "format=duration",
+                   "-of", "csv=p=0", path])
+    try:
+        dur = float(durtxt.strip().split("\n")[0])
+    except Exception:
+        dur = 0.0
+    vol = _run(["ffmpeg", "-hide_banner", "-nostats", "-i", path,
+                "-af", "volumedetect", "-f", "null", "-"])
+    ast = _run(["ffmpeg", "-hide_banner", "-nostats", "-i", path,
+                "-af", "astats=metadata=1", "-f", "null", "-"])
+    sil = _run(["ffmpeg", "-hide_banner", "-nostats", "-i", path,
+                "-af", "silencedetect=noise=-50dB:d=0.4", "-f", "null", "-"])
+
+    overall_flat, median_flat, garble = _flatness_windows(path)
+    m = AudioMetrics(
+        label=label, has_audio=True, duration=dur,
+        mean_db=_f(r"mean_volume:\s*(-?[0-9.]+) dB", vol),
+        max_db=_f(r"max_volume:\s*(-?[0-9.]+) dB", vol),
+        peak_db=_f(r"Peak level dB:\s*(-?[0-9.inf]+)", ast),
+        flat_factor=_f(r"Flat factor:\s*([0-9.]+)", ast),
+        dc_offset=_f(r"DC offset:\s*(-?[0-9.]+)", ast),
+        spectral_flatness=overall_flat,
+        flatness_median=median_flat,
+        garble_windows=garble,
+    )
+
+    # Longest mid-clip silence gap (dropouts), excluding leading/trailing silence.
+    starts = [float(x) for x in re.findall(r"silence_start:\s*(-?[0-9.]+)", sil)]
+    ends = [float(x) for x in re.findall(r"silence_end:\s*([0-9.]+)", sil)]
+    longest = 0.0
+    for s, e in zip(starts, ends):
+        if s > 0.3 and e < dur - 0.3:
+            longest = max(longest, e - s)
+    m.mid_dropout_s = longest
+    return m
+
+
+def findings(m: AudioMetrics, *, expect_audio: bool) -> list[Finding]:
+    out: list[Finding] = []
+    if not m.has_audio:
+        if expect_audio:
+            out.append(Finding("audio.missing", Severity.CRITICAL, m.label,
+                               "Audio expected (audio_enabled) but no audio stream present."))
+        return out
+    for w in (m.garble_windows or []):
+        out.append(Finding(
+            "audio.garble", Severity.CRITICAL, f"{m.label} {w['start']:.0f}-{w['end']:.0f}s",
+            f"Broadband-noise/garble burst: window spectral flatness {w['mean']:.2f} "
+            f"(peak {w['max']:.2f}) vs track median {m.flatness_median:.2f} — "
+            f"tonal speech/music sits ~0.05-0.15.",
+            {"window": w, "track_median": m.flatness_median}))
+    if m.peak_db is not None and m.peak_db > C.AUDIO_TRUE_PEAK_MAX_DB:
+        out.append(Finding("audio.clipping", Severity.WARNING, m.label,
+                           f"Peak level {m.peak_db:.2f} dB risks clipping.",
+                           {"peak_db": m.peak_db}))
+    if m.mid_dropout_s > C.AUDIO_MID_DROPOUT_MAX_S:
+        out.append(Finding("audio.dropout", Severity.WARNING, m.label,
+                           f"Mid-shot silence gap {m.mid_dropout_s:.2f}s.",
+                           {"mid_dropout_s": m.mid_dropout_s}))
+    if m.dc_offset is not None and abs(m.dc_offset) > C.AUDIO_DC_OFFSET_MAX:
+        out.append(Finding("audio.dc_offset", Severity.WARNING, m.label,
+                           f"DC offset {m.dc_offset:.3f}.", {"dc_offset": m.dc_offset}))
+    return out
+
+
+def render_spectrogram(path: str, out_png: str) -> bool:
+    res = subprocess.run(
+        ["ffmpeg", "-hide_banner", "-nostats", "-y", "-i", path,
+         "-lavfi", "showspectrumpic=s=1200x400:legend=1", out_png],
+        capture_output=True, text=True)
+    return res.returncode == 0

--- a/backend/vidpipe/qa/audit.py
+++ b/backend/vidpipe/qa/audit.py
@@ -1,0 +1,301 @@
+"""Adversarial production audit — orchestrator, criteria evaluation, report, CLI.
+
+    python -m vidpipe.qa.audit <production_id> [--out DIR] [--api URL]
+                               [--sample-every N] [--no-embeddings] [--no-vision]
+
+Exit code is non-zero when the audit FAILS (any CRITICAL finding), so it gates
+CI / the pytest wrapper. Designed to run where ``vidpipe`` imports and Vertex/
+Ollama credentials are available (e.g. inside the backend container).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+import httpx
+
+from vidpipe.qa import audio as audio_mod
+from vidpipe.qa import vision as vision_mod
+from vidpipe.qa import criteria as C
+from vidpipe.qa.criteria import Finding, Severity, Verdict
+
+logger = logging.getLogger("vidpipe.qa")
+
+
+# --------------------------------------------------------------------------
+# Production graph
+# --------------------------------------------------------------------------
+def fetch_graph(api: str, pid: str) -> dict[str, Any]:
+    with httpx.Client(base_url=api, timeout=60, follow_redirects=True) as cx:
+        prod = cx.get(f"/api/productions/{pid}").raise_for_status().json()
+        all_scenes = cx.get("/api/scenes").raise_for_status().json()
+        items = all_scenes if isinstance(all_scenes, list) else all_scenes.get(
+            "scenes", all_scenes.get("items", []))
+        # scene_order lives on the list payload; the detail endpoint omits it, so
+        # carry it through explicitly (otherwise scene labels/timeline scramble).
+        order_by_id = {(s.get("scene_id") or s.get("id")): s.get("scene_order", 0)
+                       for s in items if s.get("production_id") == pid}
+        scenes = []
+        for sid, order in order_by_id.items():
+            d = cx.get(f"/api/scenes/{sid}").raise_for_status().json()
+            d["scene_order"] = order
+            scenes.append(d)
+        scenes.sort(key=lambda d: d["scene_order"])
+
+        # primary_ref_url lives on the actors LIST payload, not the detail endpoint.
+        actors_list = cx.get("/api/asset-library/actors").json()
+        actors_list = actors_list if isinstance(actors_list, list) else \
+            actors_list.get("actors", actors_list.get("items", []))
+        ref_by_actor = {a.get("id"): a.get("primary_ref_url") for a in actors_list}
+
+        # Characters from the bible cast (on-screen only; with reference photos).
+        characters: dict[str, dict] = {}
+        bible_id = prod.get("production_bible_id")
+        if bible_id:
+            cast = cx.get(f"/api/production-bibles/{bible_id}/cast").json()
+            cast = cast if isinstance(cast, list) else cast.get("cast", cast.get("items", []))
+            for c in cast:
+                if (c.get("role") or "").upper() == "NARRATOR":
+                    continue
+                actor_id = c.get("actor_id")
+                ref_bytes = None
+                ref_url = ref_by_actor.get(actor_id)
+                if ref_url:
+                    # Use the full-res image, not the thumbnail, for embeddings.
+                    r = cx.get(ref_url.replace("?thumb=true", ""))
+                    if r.status_code == 200:
+                        ref_bytes = r.content
+                characters[c.get("tag")] = {
+                    "name": c.get("character_name"),
+                    "appearance": c.get("character_description") or "",
+                    "role": c.get("role"),
+                    "ref_bytes": ref_bytes,
+                }
+    return {"production": prod, "scenes": scenes, "characters": characters}
+
+
+def _download(api: str, url: str, dest: Path) -> Optional[Path]:
+    if not url:
+        return None
+    with httpx.Client(base_url=api, timeout=120, follow_redirects=True) as cx:
+        r = cx.get(url)
+        if r.status_code != 200:
+            return None
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(r.content)
+    return dest
+
+
+def _sample_frames(clip: Path, every_n: int, outdir: Path, limit: int) -> list[Path]:
+    outdir.mkdir(parents=True, exist_ok=True)
+    pat = str(outdir / "f_%03d.png")
+    subprocess.run(["ffmpeg", "-hide_banner", "-nostats", "-y", "-i", str(clip),
+                    "-vf", f"select=not(mod(n\\,{every_n})),scale=512:-1",
+                    "-vsync", "vfr", pat], capture_output=True, text=True)
+    frames = sorted(outdir.glob("f_*.png"))
+    if len(frames) > limit:  # even spread
+        step = len(frames) / limit
+        frames = [frames[int(i * step)] for i in range(limit)]
+    return frames
+
+
+# --------------------------------------------------------------------------
+# Audit
+# --------------------------------------------------------------------------
+async def _load_user_settings():
+    try:
+        from sqlalchemy import select
+        from vidpipe.db.engine import async_session
+        from vidpipe.db.models import UserSettings
+        async with async_session() as s:
+            return (await s.execute(select(UserSettings))).scalars().first()
+    except Exception as e:  # noqa: BLE001
+        logger.info("No UserSettings loaded (%s); Ollama cloud config may be absent.", e)
+        return None
+
+
+async def run_audit(api: str, pid: str, out: Path, *, sample_every: int,
+                    do_embed: bool, do_vision: bool) -> Verdict:
+    out.mkdir(parents=True, exist_ok=True)
+    g = fetch_graph(api, pid)
+    scenes, chars = g["scenes"], g["characters"]
+    v = Verdict(production_id=pid, meta={
+        "name": g["production"].get("name"),
+        "n_scenes": len(scenes),
+        "characters": {k: {"name": d["name"], "has_ref": d["ref_bytes"] is not None}
+                       for k, d in chars.items()},
+    })
+
+    # Protagonist = first LEAD with a reference, else first character with a ref.
+    lead = next((c for c in chars.values() if (c.get("role") or "").upper() == "LEAD"
+                 and c["ref_bytes"]), None) or \
+        next((c for c in chars.values() if c["ref_bytes"]), None)
+    v.meta["protagonist"] = lead["name"] if lead else None
+    if lead and lead["ref_bytes"]:
+        (out / "reference.png").write_bytes(lead["ref_bytes"])
+
+    timeline: list[dict] = []   # cumulative shot offsets in the concatenated master
+    cursor = 0.0
+
+    vision_model = scenes[0].get("vision_model") if scenes else None
+    v.meta["vision_model"] = vision_model
+    v.meta["embeddings_available"] = bool(do_embed and vision_mod.embeddings_available())
+    adapter = None
+    if do_vision and vision_model:
+        # Reproduce the app's startup credential bootstrap so the selected vision
+        # LLM (Vertex/Gemini or Ollama) authenticates exactly as the pipeline does.
+        try:
+            from vidpipe.services.vertex_client import load_vertex_credentials_from_db
+            await load_vertex_credentials_from_db()
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Vertex credential bootstrap failed: %s", e)
+        from vidpipe.services.llm.registry import get_adapter
+        adapter = get_adapter(vision_model, await _load_user_settings())
+
+    for si, sc in enumerate(scenes, 1):
+        sid = sc.get("scene_id") or sc.get("id")
+        slug = sc.get("title") or f"scene {si}"
+        sdir = out / f"S{si}"
+        shots = sc.get("shots", [])
+        audio_expected = bool(sc.get("audio_enabled"))
+
+        for shot in shots:
+            i = shot.get("shot_index")
+            tag = f"S{si} shot {i}"
+            # ---- establishing keyframe identity (scene's shot 0 start) ----
+            if i == 0 and lead:
+                kf = _download(api, shot.get("start_keyframe_url"), sdir / "establish.png")
+                if kf:
+                    # embedding
+                    if v.meta["embeddings_available"]:
+                        sim = vision_mod.embedding_similarity(lead["ref_bytes"], kf.read_bytes())
+                        if sim is None:
+                            v.add(Finding("identity.no_face", Severity.WARNING,
+                                          f"{tag} establishing kf",
+                                          "No face detected to embed (stylization or wrong subject)."))
+                        elif sim < C.FACE_EMBED_MIN:
+                            v.add(Finding("identity.embed_low", Severity.WARNING,
+                                          f"{tag} establishing kf",
+                                          f"Face-embedding similarity {sim:.2f} < {C.FACE_EMBED_MIN}.",
+                                          {"similarity": sim}))
+                    # vision LLM
+                    if adapter:
+                        verdict = await vision_mod.judge_identity(
+                            adapter, kf.read_bytes(), character_name=lead["name"],
+                            appearance=lead["appearance"],
+                            scene_intent=f"{slug}: {sc.get('prompt','')[:300]}")
+                        if verdict is None:
+                            v.add(Finding("vision.error", Severity.WARNING, f"{tag} establishing kf",
+                                          "Vision-LLM judge returned no verdict."))
+                        else:
+                            sev = (Severity.CRITICAL if verdict.identity_match < C.IDENTITY_VISION_MIN
+                                   else Severity.WARNING if verdict.identity_match < C.IDENTITY_VISION_WARN
+                                   else Severity.INFO)
+                            if sev != Severity.INFO:
+                                v.add(Finding(
+                                    "identity.establishing", sev, f"{tag} establishing kf",
+                                    f"{lead['name']} identity_match={verdict.identity_match:.2f} "
+                                    f"({'; '.join(verdict.discrepancies) or 'see notes'}).",
+                                    {"identity_match": verdict.identity_match,
+                                     "observed": verdict.observed_subject,
+                                     "discrepancies": verdict.discrepancies,
+                                     "vision_model": vision_model}))
+                            if verdict.scene_alignment < 0.5:
+                                v.add(Finding("story.scene_alignment", Severity.WARNING,
+                                              f"{tag} establishing kf",
+                                              f"Weak scene alignment {verdict.scene_alignment:.2f}: "
+                                              f"{verdict.scene_notes[:160]}",
+                                              {"scene_alignment": verdict.scene_alignment}))
+
+            # ---- per-shot clip audio + identity drift on sampled frames ----
+            clip = _download(api, shot.get("clip_url"), sdir / f"shot{i}.mp4")
+            if clip:
+                m = audio_mod.analyze(str(clip), tag)
+                if m.duration:
+                    timeline.append({"start": cursor, "end": cursor + m.duration, "label": tag})
+                    cursor += m.duration
+                for f in audio_mod.findings(m, expect_audio=audio_expected):
+                    v.add(f)
+                if v.meta["embeddings_available"] and lead:
+                    frames = _sample_frames(clip, sample_every, sdir / f"shot{i}_frames", limit=3)
+                    sims = [vision_mod.embedding_similarity(lead["ref_bytes"], fp.read_bytes())
+                            for fp in frames]
+                    sims = [s for s in sims if s is not None]
+                    if sims and min(sims) < C.FACE_EMBED_MIN:
+                        v.add(Finding("identity.drift", Severity.WARNING, tag,
+                                      f"Identity drift in clip: min frame similarity {min(sims):.2f}.",
+                                      {"frame_similarities": [round(s, 3) for s in sims]}))
+
+    # ---- master audio integrity + garble localization ----
+    master = _download(api, f"/api/productions/{pid}/master-video", out / "master.mp4")
+    if master:
+        mm = audio_mod.analyze(str(master), "master")
+        v.meta["master_audio"] = mm.as_dict()
+
+        def _attribute(win: dict) -> str:
+            mid = (win["start"] + win["end"]) / 2
+            for seg in timeline:
+                if seg["start"] <= mid < seg["end"]:
+                    return seg["label"]
+            return "master tail"
+
+        for f in audio_mod.findings(mm, expect_audio=True):
+            if f.code == "audio.garble" and f.evidence.get("window"):
+                shot_lbl = _attribute(f.evidence["window"])
+                f.where = f"{shot_lbl} (master {f.evidence['window']['start']:.0f}-{f.evidence['window']['end']:.0f}s)"
+                f.message = f"{f.message} Attributed to {shot_lbl}."
+            v.add(f)
+        audio_mod.render_spectrogram(str(master), str(out / "master_spectrogram.png"))
+
+    _write_reports(v, out)
+    return v
+
+
+def _write_reports(v: Verdict, out: Path) -> None:
+    (out / "report.json").write_text(json.dumps(v.as_dict(), indent=2))
+    lines = [f"# Video QA Audit — {v.meta.get('name')}",
+             f"\n**Production:** `{v.production_id}`  ",
+             f"**Result:** {'✅ PASS' if v.passed else '❌ FAIL'}  ",
+             f"**Critical:** {len(v.critical)} · **Warnings:** {len(v.warnings)}  ",
+             f"**Vision model:** {v.meta.get('vision_model')} · "
+             f"**Face embeddings:** {'on' if v.meta.get('embeddings_available') else 'unavailable'}  ",
+             f"**Protagonist:** {v.meta.get('protagonist')}\n"]
+    for sev in (Severity.CRITICAL, Severity.WARNING, Severity.INFO):
+        fs = [f for f in v.findings if f.severity == sev]
+        if not fs:
+            continue
+        lines.append(f"\n## {sev.value.upper()} ({len(fs)})\n")
+        for f in fs:
+            lines.append(f"- **[{f.code}]** _{f.where}_ — {f.message}")
+    (out / "report.md").write_text("\n".join(lines) + "\n")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description="Adversarial video-QA audit of a production.")
+    ap.add_argument("production_id")
+    ap.add_argument("--api", default=os.getenv("VIDPIPE_QA_API_BASE", "http://localhost:8000"))
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--sample-every", type=int, default=10)
+    ap.add_argument("--no-embeddings", action="store_true")
+    ap.add_argument("--no-vision", action="store_true")
+    a = ap.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    out = Path(a.out or f"/tmp/qa/{a.production_id}")
+    v = asyncio.run(run_audit(a.api, a.production_id, out,
+                              sample_every=a.sample_every,
+                              do_embed=not a.no_embeddings, do_vision=not a.no_vision))
+    print((out / "report.md").read_text())
+    print(f"\nReports + evidence in: {out}")
+    return 0 if v.passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/vidpipe/qa/criteria.py
+++ b/backend/vidpipe/qa/criteria.py
@@ -1,0 +1,80 @@
+"""Quality criteria, severities, and the finding/verdict data model.
+
+Thresholds live here so the standard is explicit and tunable in one place.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+
+class Severity(str, Enum):
+    INFO = "info"
+    WARNING = "warning"      # below ideal, does not by itself fail the audit
+    CRITICAL = "critical"    # fails the audit → triggers re-generation
+
+
+# ---- Identity / vision thresholds ----------------------------------------
+# Vision-LLM identity_match is 0..1. Face-embedding cosine similarity is 0..1.
+IDENTITY_VISION_MIN = 0.70          # establishing keyframe must clearly be the character
+IDENTITY_VISION_WARN = 0.85         # below this on any sampled frame → warning
+FACE_EMBED_MIN = 0.35               # InsightFace cosine; stylized art runs low, so advisory-ish
+# A scene's *establishing* keyframe (shot 0 start) is the strictest gate.
+
+# ---- Audio thresholds ----------------------------------------------------
+AUDIO_TRUE_PEAK_MAX_DB = -0.1       # above this → clipping risk
+AUDIO_SPECTRAL_FLATNESS_MAX = 0.45  # broadband-noise/garble heuristic (0=tonal,1=white noise)
+AUDIO_MID_DROPOUT_MAX_S = 0.6       # silence gap inside a shot longer than this → dropout
+AUDIO_DC_OFFSET_MAX = 0.02
+
+
+@dataclass
+class Finding:
+    code: str                       # e.g. "identity.establishing_miss"
+    severity: Severity
+    where: str                      # e.g. "S1 shot 0 start keyframe" / "master 52-58s"
+    message: str
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "code": self.code,
+            "severity": self.severity.value,
+            "where": self.where,
+            "message": self.message,
+            "evidence": self.evidence,
+        }
+
+
+@dataclass
+class Verdict:
+    production_id: str
+    findings: list[Finding] = field(default_factory=list)
+    meta: dict[str, Any] = field(default_factory=dict)
+
+    def add(self, f: Finding) -> None:
+        self.findings.append(f)
+
+    @property
+    def critical(self) -> list[Finding]:
+        return [f for f in self.findings if f.severity == Severity.CRITICAL]
+
+    @property
+    def warnings(self) -> list[Finding]:
+        return [f for f in self.findings if f.severity == Severity.WARNING]
+
+    @property
+    def passed(self) -> bool:
+        return len(self.critical) == 0
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "production_id": self.production_id,
+            "passed": self.passed,
+            "n_critical": len(self.critical),
+            "n_warning": len(self.warnings),
+            "findings": [f.as_dict() for f in self.findings],
+            "meta": self.meta,
+        }

--- a/backend/vidpipe/qa/vision.py
+++ b/backend/vidpipe/qa/vision.py
@@ -1,0 +1,129 @@
+"""Identity / story-alignment judges.
+
+Two independent signals, per the QA design:
+
+1. Face-embedding similarity (InsightFace) — objective image-vs-image identity
+   score between a candidate keyframe and the character's Bible reference photo.
+   Degrades gracefully: returns None when the lib/model is unavailable or no
+   face is detected (itself a reportable condition for character shots).
+
+2. Vision-LLM semantic judge — uses the production's *selected* vision model
+   (Gemini or Ollama) via ``get_adapter``; checks the candidate against the
+   canonical Bible appearance and the scene intent. Prompted adversarially:
+   default to a low score when uncertain.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+# --- Face-embedding judge (optional dependency) ---------------------------
+_FACE_APP = None
+_FACE_TRIED = False
+
+
+def _face_app():
+    global _FACE_APP, _FACE_TRIED
+    if _FACE_TRIED:
+        return _FACE_APP
+    _FACE_TRIED = True
+    try:
+        from insightface.app import FaceAnalysis  # type: ignore
+
+        app = FaceAnalysis(name="buffalo_l", providers=["CPUExecutionProvider"])
+        app.prepare(ctx_id=-1, det_size=(640, 640))
+        _FACE_APP = app
+        logger.info("InsightFace ready (buffalo_l, CPU).")
+    except Exception as e:  # noqa: BLE001 - any failure → embeddings unavailable
+        logger.warning("Face-embedding judge unavailable: %s", e)
+        _FACE_APP = None
+    return _FACE_APP
+
+
+def _largest_embedding(img_bytes: bytes):
+    app = _face_app()
+    if app is None:
+        return None
+    try:
+        import cv2  # type: ignore
+        import numpy as np  # type: ignore
+
+        arr = np.frombuffer(img_bytes, dtype=np.uint8)
+        img = cv2.imdecode(arr, cv2.IMREAD_COLOR)
+        if img is None:
+            return None
+        faces = app.get(img)
+        if not faces:
+            return None
+        faces.sort(key=lambda f: (f.bbox[2] - f.bbox[0]) * (f.bbox[3] - f.bbox[1]))
+        return faces[-1].normed_embedding
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Embedding extraction failed: %s", e)
+        return None
+
+
+def embedding_similarity(ref_bytes: bytes, cand_bytes: bytes) -> Optional[float]:
+    """Cosine similarity of largest faces, or None if either has no detectable face."""
+    e_ref = _largest_embedding(ref_bytes)
+    e_cand = _largest_embedding(cand_bytes)
+    if e_ref is None or e_cand is None:
+        return None
+    import numpy as np  # type: ignore
+
+    return float(np.dot(e_ref, e_cand))  # both are L2-normalized
+
+
+def embeddings_available() -> bool:
+    return _face_app() is not None
+
+
+# --- Vision-LLM judge -----------------------------------------------------
+class IdentityVerdict(BaseModel):
+    identity_match: float = Field(..., ge=0.0, le=1.0,
+        description="0..1 confidence the depicted person matches the canonical character description.")
+    is_on_model: bool = Field(..., description="True only if all key, hard-to-change features match.")
+    observed_subject: str = Field(..., description="Brief description of who/what is actually shown.")
+    discrepancies: list[str] = Field(default_factory=list,
+        description="Specific mismatches vs the canonical description (e.g. 'has hair; should be bald').")
+    scene_alignment: float = Field(..., ge=0.0, le=1.0,
+        description="0..1 how well the image depicts the described scene intent/setting.")
+    scene_notes: str = Field("", description="Notes on scene/setting alignment.")
+
+
+def _identity_prompt(character_name: str, appearance: str, scene_intent: str) -> str:
+    return (
+        "You are a strict, adversarial film continuity QA reviewer. Your job is to "
+        "CATCH identity errors, not to be charitable.\n\n"
+        f"CANONICAL CHARACTER — {character_name}:\n{appearance}\n\n"
+        f"INTENDED SCENE:\n{scene_intent}\n\n"
+        "Examine the attached frame. Judge whether the most prominent person IS this "
+        "exact character, focusing on hard-to-change features (hairline/baldness, "
+        "face shape, glasses style, facial hair, distinguishing marks). Wardrobe and "
+        "lighting may vary; identity must not.\n"
+        "Rules: if NO clearly visible person, set identity_match=0 and note it. If "
+        "uncertain, score LOW. List concrete discrepancies. Also rate how well the "
+        "image depicts the intended scene (setting/action), independent of identity."
+    )
+
+
+async def judge_identity(adapter, image_bytes: bytes, *, character_name: str,
+                         appearance: str, scene_intent: str,
+                         mime_type: str = "image/png") -> Optional[IdentityVerdict]:
+    """Run the selected vision LLM. Returns None on adapter error."""
+    try:
+        result = await adapter.analyze_image(
+            image_bytes,
+            _identity_prompt(character_name, appearance, scene_intent),
+            IdentityVerdict,
+            mime_type=mime_type,
+            temperature=0.1,
+        )
+        return result  # type: ignore[return-value]
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Vision-LLM judge failed: %s", e)
+        return None

--- a/backend/vidpipe/schemas/llm_vision.py
+++ b/backend/vidpipe/schemas/llm_vision.py
@@ -156,3 +156,32 @@ class PropMetadataOutput(BaseModel):
         "wear/condition, distinctive details, lighting interaction (reflective, matte, etc.), "
         "viewing angle. ~80-120 words."
     )
+
+
+class IdentityReferenceRating(BaseModel):
+    """Per-image rating for identity-reference suitability."""
+
+    index: int = Field(description="Zero-based index of the image panel being rated")
+    face_clearly_visible: bool = Field(
+        description="True if a human face is clearly visible (not from behind, not tiny)"
+    )
+    eyes_unobstructed: bool = Field(
+        description="True if the eyes are visible and NOT hidden by sunglasses, shadow, or other occlusion"
+    )
+    suitability: float = Field(
+        description="0-10 score for how suitable this image is as an identity reference "
+        "for image generation (frontal, sharp, unobstructed face scores high)"
+    )
+
+
+class IdentityReferenceQualificationOutput(BaseModel):
+    """Structured output ranking candidate identity reference images.
+
+    Used by keyframes.py to pick the best character references for
+    multi-reference ComfyUI image models (occluded/sunglasses references
+    dilute identity conditioning).
+    """
+
+    ratings: list[IdentityReferenceRating] = Field(
+        description="One rating per numbered image panel, in panel order"
+    )

--- a/backend/vidpipe/services/checkpoint_service.py
+++ b/backend/vidpipe/services/checkpoint_service.py
@@ -247,20 +247,26 @@ async def create_checkpoint(
 
     parent_sha = scene.head_sha  # None for first checkpoint
 
-    # Skip if snapshot is unchanged (same SHA as current head)
-    if sha == parent_sha:
+    # Idempotent: reuse any existing checkpoint with this exact content SHA for
+    # the scene — not just the current head. Regenerating a scene back to a
+    # previously-checkpointed state (common after repeated regens) produces a SHA
+    # that already exists elsewhere in history; inserting it again violates
+    # uq_checkpoint_scene_sha. Reuse it and move head there instead.
+    existing = (await session.execute(
+        select(SceneCheckpoint).where(
+            SceneCheckpoint.scene_id == scene.id,
+            SceneCheckpoint.sha == sha,
+        )
+    )).scalar_one_or_none()
+    if existing is not None:
+        if scene.head_sha != sha:
+            scene.head_sha = sha
+            await session.flush()
         logger.info(
-            "Checkpoint skipped for scene %s — snapshot unchanged (sha=%s): %s",
+            "Checkpoint reused for scene %s (sha=%s, unchanged content): %s",
             scene.id, sha[:8], message,
         )
-        # Return existing checkpoint so callers don't break
-        existing = await session.execute(
-            select(SceneCheckpoint).where(
-                SceneCheckpoint.scene_id == scene.id,
-                SceneCheckpoint.sha == sha,
-            )
-        )
-        return existing.scalar_one()
+        return existing
 
     checkpoint = SceneCheckpoint(
         scene_id=scene.id,

--- a/backend/vidpipe/services/clip_validation.py
+++ b/backend/vidpipe/services/clip_validation.py
@@ -1,0 +1,251 @@
+"""Degenerate-clip detection for generated video clips.
+
+ComfyUI Cloud occasionally returns a structurally valid MP4 whose decoded
+frames are garbage (observed: WAN 2.2 FLF2V jobs where the server-side QC
+frames were clean but the encoded video contained a static noise pattern for
+every frame between the two pinned conditioning frames). The job reports
+success, so the only way to catch it is to inspect the downloaded video.
+
+Detection strategy (validated against real corrupted + good clips):
+
+1. Per-frame noise signature — the ratio of mid-frequency to low-frequency
+   band energy. Natural frames follow a ~1/f spectrum (measured <= 0.30,
+   including near-black occlusion frames); the observed corruption is
+   mid-band texture with no large-scale structure (measured >= 3.8).
+2. Start/end keyframe anchors — the first frame must correlate with the start
+   keyframe (catches wrong-video downloads); the last frame must correlate
+   with the end keyframe when one conditioned the generation (FLF2V).
+
+Temporal continuity between adjacent samples is computed for diagnostics but
+is NOT a hard gate: legitimate clips can contain near-discontinuities (e.g.
+an object sweeping across the lens was observed in a good LTX clip).
+
+All comparisons use Pearson correlation of downscaled grayscale frames.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+import tempfile
+from dataclasses import dataclass
+
+import numpy as np
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+# Downscale target for frame-vs-frame / frame-vs-keyframe comparison.
+_COMPARE_SIZE = (208, 120)
+
+# Seconds between adjacent samples in the continuity chain.
+_HOP_SECONDS = 0.25
+
+# Thresholds — all lenient relative to measured margins.
+_START_ANCHOR_THRESHOLD = 0.45  # good >= 0.92
+_END_ANCHOR_THRESHOLD = 0.35    # good >= 0.89
+_NOISE_BAND_RATIO = 1.0         # natural <= 0.30; noise >= 3.8
+_NOISE_BAND_MIN_ENERGY = 3.0    # ignore ratio on near-uniform frames
+_FLAT_FRAME_STD = 15.0          # occlusion frame low-band std 11.5; good >= 38
+
+
+@dataclass(frozen=True)
+class ClipValidationResult:
+    ok: bool
+    detail: str
+    # Mean absolute frame-to-frame difference across sampled frames (grayscale,
+    # downscaled). A quality signal — NOT a corruption gate. Calibrated values:
+    # frozen/near-static clips measure < 5; lively clips measure 7-37.
+    # 0.0 when fewer than two frames decoded.
+    motion_mean: float = 0.0
+
+
+@dataclass(frozen=True)
+class _SampledFrame:
+    compare: np.ndarray   # grayscale at _COMPARE_SIZE
+    band_mid: float       # band energy between 1/4 and 1/16 scale
+    band_low: float       # large-scale structure (1/16 scale std)
+
+
+def _gray_from_bytes(image_bytes: bytes) -> np.ndarray:
+    img = Image.open(io.BytesIO(image_bytes))
+    return np.asarray(img.convert("L").resize(_COMPARE_SIZE), dtype=np.float64)
+
+
+def _pearson(a: np.ndarray, b: np.ndarray) -> float:
+    a = a.flatten()
+    b = b.flatten()
+    if a.std() < 1e-6 or b.std() < 1e-6:
+        return 0.0
+    return float(np.corrcoef(a, b)[0, 1])
+
+
+def _analyze_frame(gray_full: Image.Image) -> _SampledFrame:
+    """Compute comparison image + frequency band energies for one frame."""
+    w, h = gray_full.size
+    d4 = gray_full.resize((max(1, w // 4), max(1, h // 4)))
+    d16 = gray_full.resize((max(1, w // 16), max(1, h // 16)))
+    a4 = np.asarray(d4, dtype=np.float64)
+    u4 = np.asarray(d16.resize(d4.size), dtype=np.float64)
+    band_mid = float((a4 - u4).std())
+    band_low = float(np.asarray(d16, dtype=np.float64).std())
+    compare = np.asarray(gray_full.resize(_COMPARE_SIZE), dtype=np.float64)
+    return _SampledFrame(compare=compare, band_mid=band_mid, band_low=band_low)
+
+
+def _is_noise(frame: _SampledFrame) -> bool:
+    if frame.band_mid < _NOISE_BAND_MIN_ENERGY:
+        return False
+    return frame.band_mid / max(frame.band_low, 0.1) > _NOISE_BAND_RATIO
+
+
+def _compute_motion_mean(frames: list[_SampledFrame]) -> float:
+    """Mean absolute frame-to-frame difference across sampled frames.
+
+    Reuses the already-decoded ``compare`` grayscale arrays (zero extra
+    decode cost). Pairs where either frame is genuinely flat (e.g. a dark
+    occlusion frame) are skipped, mirroring the continuity diagnostic, so a
+    brief blackout does not inflate or deflate the score.
+    """
+    diffs: list[float] = []
+    for i in range(len(frames) - 1):
+        if _is_flat(frames[i]) or _is_flat(frames[i + 1]):
+            continue
+        diffs.append(float(np.abs(frames[i + 1].compare - frames[i].compare).mean()))
+    if not diffs:
+        return 0.0
+    return float(np.mean(diffs))
+
+
+def _is_flat(frame: _SampledFrame) -> bool:
+    return frame.band_low < _FLAT_FRAME_STD
+
+
+def _sample_frames(video_path: str, hop_seconds: float) -> list[_SampledFrame]:
+    """Decode the clip and analyze frames every hop.
+
+    Always includes the first and last decodable frame.
+    """
+    import cv2
+
+    cap = cv2.VideoCapture(video_path)
+    try:
+        fps = cap.get(cv2.CAP_PROP_FPS) or 16.0
+        hop_frames = max(1, int(round(fps * hop_seconds)))
+
+        samples: list[_SampledFrame] = []
+        last_frame: _SampledFrame | None = None
+        index = 0
+        last_sampled_index = -1
+        while True:
+            ok, frame = cap.read()
+            if not ok:
+                break
+            gray = Image.fromarray(
+                cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+            )
+            analyzed = _analyze_frame(gray)
+            last_frame = analyzed
+            if index % hop_frames == 0:
+                samples.append(analyzed)
+                last_sampled_index = index
+            index += 1
+
+        # Ensure the true final frame participates in the checks
+        if last_frame is not None and last_sampled_index != index - 1:
+            samples.append(last_frame)
+        return samples
+    finally:
+        cap.release()
+
+
+def validate_clip_integrity(
+    video_bytes: bytes,
+    *,
+    start_frame_bytes: bytes | None = None,
+    end_frame_bytes: bytes | None = None,
+) -> ClipValidationResult:
+    """Check a downloaded clip for degenerate/corrupted content.
+
+    Args:
+        video_bytes: The full video file as bytes.
+        start_frame_bytes: Start keyframe that conditioned generation, if any.
+        end_frame_bytes: End keyframe that conditioned generation (FLF2V), if any.
+
+    Returns:
+        ClipValidationResult — ``ok=False`` means the clip should not be
+        accepted (corrupted, or not the video we asked for).
+    """
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
+            f.write(video_bytes)
+            tmp_path = f.name
+
+        frames = _sample_frames(tmp_path, _HOP_SECONDS)
+    finally:
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+    if len(frames) < 2:
+        return ClipValidationResult(
+            ok=False, detail=f"undecodable_video: only {len(frames)} frame(s) decoded"
+        )
+
+    # 1. Per-frame noise signature
+    noise_count = sum(1 for f in frames if _is_noise(f))
+    if noise_count > 0:
+        return ClipValidationResult(
+            ok=False,
+            detail=(
+                f"noise_frames: {noise_count} of {len(frames)} sampled frames "
+                "have a mid-frequency noise spectrum (no large-scale structure)"
+            ),
+        )
+
+    motion_mean = _compute_motion_mean(frames)
+
+    # Diagnostic only — legitimate clips can contain near-discontinuities
+    min_hop = 1.0
+    for i in range(len(frames) - 1):
+        if _is_flat(frames[i]) or _is_flat(frames[i + 1]):
+            continue
+        min_hop = min(min_hop, _pearson(frames[i].compare, frames[i + 1].compare))
+
+    checks = [f"continuity_min={min_hop:.3f}", f"motion={motion_mean:.2f}"]
+
+    # 2. Start-frame anchor
+    if start_frame_bytes is not None and not _is_flat(frames[0]):
+        corr = _pearson(frames[0].compare, _gray_from_bytes(start_frame_bytes))
+        if corr < _START_ANCHOR_THRESHOLD:
+            return ClipValidationResult(
+                ok=False,
+                detail=(
+                    f"start_frame_mismatch: correlation {corr:.3f} < "
+                    f"{_START_ANCHOR_THRESHOLD} — clip does not begin at the "
+                    "start keyframe"
+                ),
+            )
+        checks.append(f"start_anchor={corr:.3f}")
+
+    # 3. End-frame anchor (only when an end keyframe conditioned generation)
+    if end_frame_bytes is not None and not _is_flat(frames[-1]):
+        corr = _pearson(frames[-1].compare, _gray_from_bytes(end_frame_bytes))
+        if corr < _END_ANCHOR_THRESHOLD:
+            return ClipValidationResult(
+                ok=False,
+                detail=(
+                    f"end_frame_mismatch: correlation {corr:.3f} < "
+                    f"{_END_ANCHOR_THRESHOLD} — clip does not end at the "
+                    "end keyframe"
+                ),
+            )
+        checks.append(f"end_anchor={corr:.3f}")
+
+    return ClipValidationResult(
+        ok=True, detail=" ".join(checks), motion_mean=motion_mean
+    )

--- a/backend/vidpipe/services/comfyui_adapter.py
+++ b/backend/vidpipe/services/comfyui_adapter.py
@@ -54,8 +54,12 @@ WAN_I2V_NEGATIVE_PROMPT = (
     "inconsistent face, cropped head, decapitated framing"
 )
 
-# Generic video negative prompt for LTX (no model-specific tuning yet)
+# Generic video negative prompt for LTX. The static/motionless terms matter:
+# LTX FLF2V interprets gentle motion prompts very literally and can produce a
+# near-still clip (measured frame-diff 0.79 vs 30+ for the same keyframes/seed
+# with motion-forward prompting).
 LTX_NEGATIVE_PROMPT = (
+    "static, still image, frozen, motionless scene, no movement, "
     "blurry, out of focus, overexposed, underexposed, low contrast, "
     "washed out colors, excessive noise, grainy texture, poor lighting, "
     "flickering, motion blur, distorted proportions, unnatural skin tones, "
@@ -65,11 +69,61 @@ LTX_NEGATIVE_PROMPT = (
     "unnatural transitions, tilted camera, AI artifacts"
 )
 
+# Motion-forward prefix for LTX — without it, FLF2V conditioning eases in so
+# conservatively that the first seconds of a clip can be effectively frozen.
+_LTX_MOTION_PREFIX = (
+    "Continuous visible motion from the very first frame, with the subject "
+    "and environment in clear movement throughout the clip. "
+)
+
 # Framing-safety prefix for models without reference-image support
 _FRAMING_SAFETY_PREFIX = (
     "Keep the subject's face and full head visible in frame throughout the entire clip. "
     "Maintain consistent character appearance and proportions. "
 )
+
+# Freeze-word substitutions for motion escalation. Order matters: longer,
+# multi-word phrases first so they win over single-word replacements.
+_MOTION_FREEZE_SUBSTITUTIONS: tuple[tuple[str, str], ...] = (
+    ("remains static", "moves dynamically"),
+    ("remains still", "keeps moving"),
+    ("stays still", "keeps moving"),
+    ("static camera", "actively moving camera"),
+    ("smooth, steady", "fast, energetic"),
+    ("smooth and steady", "fast and energetic"),
+    ("slow dolly", "fast dolly"),
+    ("slowly", "continuously and energetically"),
+    ("gently", "vigorously"),
+    ("subtle", "pronounced"),
+    ("steady", "sweeping"),
+    ("motionless", "in constant motion"),
+    ("barely moving", "moving briskly"),
+)
+
+# Strong override sentence prepended on motion escalation.
+_MOTION_ESCALATION_PREFIX = (
+    "HIGH MOTION: every part of the frame must be in obvious, continuous "
+    "movement from the very first frame — the subject moving briskly, the "
+    "camera tracking dynamically, and the environment (crowd, rain, steam, "
+    "lights, traffic) all visibly animated. Avoid any static or frozen moment. "
+)
+
+
+def escalate_motion_prompt(prompt: str) -> str:
+    """Rewrite a motion prompt to force visible motion from an LTX/ComfyUI model.
+
+    Used when a generated clip measured near-static: replaces freeze-inducing
+    language ("slowly", "steady", "remains static", ...) with energetic
+    equivalents and prepends a strong high-motion override. Pure function so it
+    can be unit-tested and reused by the regen path. Case-insensitive matching;
+    replacements use the energetic form's casing.
+    """
+    import re
+
+    rewritten = prompt
+    for needle, replacement in _MOTION_FREEZE_SUBSTITUTIONS:
+        rewritten = re.sub(re.escape(needle), replacement, rewritten, flags=re.IGNORECASE)
+    return _MOTION_ESCALATION_PREFIX + rewritten
 
 _VIDEO_OUTPUT_KEYS = ("videos", "video", "gifs", "images")
 _VIDEO_EXTENSIONS = (".mp4", ".webm", ".avi", ".mov", ".mkv")
@@ -77,6 +131,10 @@ _VIDEO_EXTENSIONS = (".mp4", ".webm", ".avi", ".mov", ".mkv")
 # Status normalization sets
 _COMPLETED_STATUSES = frozenset({"completed", "success", "done"})
 _FAILED_STATUSES = frozenset({"failed", "error", "cancelled"})
+# Comfy Cloud holds jobs in queue states (observed: "queued_limited" when the
+# account concurrency limit is hit) before any execution starts. Time spent
+# queued must not count against execution timeouts.
+QUEUED_STATUSES = frozenset({"queued", "queued_limited", "pending"})
 
 
 # ---------------------------------------------------------------------------
@@ -136,7 +194,7 @@ COMFY_VIDEO_SPECS: dict[str, ComfyVideoModelSpec] = {
         supports_end_frame=True,
         supports_audio=True,
         supports_char_refs=False,
-        prompt_prefix=None,
+        prompt_prefix=_LTX_MOTION_PREFIX,
     ),
     "seedance-2.0-flf2v": ComfyVideoModelSpec(
         fps=24,
@@ -436,7 +494,7 @@ class ComfyUIVideoAdapter:
 
         Returns:
             (status, error_message) where status is one of:
-            "completed", "running", "failed".
+            "completed", "running", "queued", "failed".
         """
         prompt_id = operation_id.removeprefix("comfyui:")
         raw_status, error_msg = await self.client.poll_status(prompt_id)
@@ -452,6 +510,11 @@ class ComfyUIVideoAdapter:
                 prompt_id, raw_status, error_msg,
             )
             return "failed", error_msg or f"ComfyUI job {raw_status}"
+        elif raw_status in QUEUED_STATUSES:
+            logger.debug(
+                "ComfyUI %s: raw_status=%r → queued", prompt_id, raw_status,
+            )
+            return "queued", None
         else:
             logger.debug(
                 "ComfyUI %s: raw_status=%r → running", prompt_id, raw_status,

--- a/backend/vidpipe/services/comfyui_adapter.py
+++ b/backend/vidpipe/services/comfyui_adapter.py
@@ -7,20 +7,33 @@ The adapter abstracts away ComfyUI-specific details (image upload, workflow
 templates, status endpoint quirks, history parsing) so the pipeline only
 deals with: submit → poll → download.
 
+Model-specific behavior (workflow builder, fps, end-frame/audio support)
+lives in COMFY_VIDEO_SPECS — add new ComfyUI video models there.
+
 Usage:
     adapter = ComfyUIVideoAdapter(comfy_client)
     op_id = await adapter.submit(video_prompt=..., start_frame_bytes=..., ...)
     status, err = await adapter.poll(op_id)
     if status == "completed":
-        video_bytes, duration = await adapter.download(op_id)
+        video_bytes, duration = await adapter.download(
+            op_id, video_model=..., duration_seconds=...)
 """
 
+import io
 import logging
+from dataclasses import dataclass
 from typing import Optional
+
+from PIL import Image
 
 from vidpipe.services.comfyui_client import (
     ComfyUIClient,
+    build_ltx23_flf2v_workflow,
+    build_seedance2_flf2v_workflow,
+    build_wan22_flf2v_workflow,
     build_wan22_i2v_workflow,
+    ltx_frames_for_duration,
+    ltx_resolution,
     wan_resolution,
 )
 
@@ -41,12 +54,114 @@ WAN_I2V_NEGATIVE_PROMPT = (
     "inconsistent face, cropped head, decapitated framing"
 )
 
+# Generic video negative prompt for LTX (no model-specific tuning yet)
+LTX_NEGATIVE_PROMPT = (
+    "blurry, out of focus, overexposed, underexposed, low contrast, "
+    "washed out colors, excessive noise, grainy texture, poor lighting, "
+    "flickering, motion blur, distorted proportions, unnatural skin tones, "
+    "deformed facial features, extra limbs, disfigured hands, "
+    "inconsistent perspective, camera shake, color banding, "
+    "cartoonish rendering, uncanny valley effect, jittery movement, "
+    "unnatural transitions, tilted camera, AI artifacts"
+)
+
+# Framing-safety prefix for models without reference-image support
+_FRAMING_SAFETY_PREFIX = (
+    "Keep the subject's face and full head visible in frame throughout the entire clip. "
+    "Maintain consistent character appearance and proportions. "
+)
+
 _VIDEO_OUTPUT_KEYS = ("videos", "video", "gifs", "images")
 _VIDEO_EXTENSIONS = (".mp4", ".webm", ".avi", ".mov", ".mkv")
 
 # Status normalization sets
 _COMPLETED_STATUSES = frozenset({"completed", "success", "done"})
 _FAILED_STATUSES = frozenset({"failed", "error", "cancelled"})
+
+
+# ---------------------------------------------------------------------------
+# Per-model specs
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class ComfyVideoModelSpec:
+    """Behavioral metadata for one ComfyUI video model.
+
+    Attributes:
+        fps: Output frame rate.
+        fixed_duration: Actual clip duration in seconds when the model ignores
+            the requested duration (WAN: always 81 frames / 16 fps). None means
+            the clip honors the requested duration.
+        supports_end_frame: Model can condition on an end keyframe.
+        supports_audio: Model can generate audio.
+        supports_char_refs: Workflow accepts character reference passthroughs.
+        prompt_prefix: Text prepended to the motion prompt at submit time
+            (framing safety for models without reference images).
+    """
+
+    fps: float
+    fixed_duration: Optional[float]
+    supports_end_frame: bool
+    supports_audio: bool
+    supports_char_refs: bool
+    prompt_prefix: Optional[str]
+
+    def clip_duration(self, requested_seconds: int) -> float:
+        """Actual output duration for a requested clip length."""
+        if self.fixed_duration is not None:
+            return self.fixed_duration
+        return float(requested_seconds)
+
+
+COMFY_VIDEO_SPECS: dict[str, ComfyVideoModelSpec] = {
+    "wan-2.2-i2v": ComfyVideoModelSpec(
+        fps=16,
+        fixed_duration=81 / 16.0,
+        supports_end_frame=False,
+        supports_audio=False,
+        supports_char_refs=False,
+        prompt_prefix=_FRAMING_SAFETY_PREFIX,
+    ),
+    "wan-2.2-flf2v": ComfyVideoModelSpec(
+        fps=16,
+        fixed_duration=81 / 16.0,
+        supports_end_frame=True,
+        supports_audio=False,
+        supports_char_refs=True,
+        prompt_prefix=_FRAMING_SAFETY_PREFIX,
+    ),
+    "ltx-2.3-flf2v": ComfyVideoModelSpec(
+        fps=25,
+        fixed_duration=None,
+        supports_end_frame=True,
+        supports_audio=True,
+        supports_char_refs=False,
+        prompt_prefix=None,
+    ),
+    "seedance-2.0-flf2v": ComfyVideoModelSpec(
+        fps=24,
+        fixed_duration=None,
+        supports_end_frame=True,
+        supports_audio=True,
+        supports_char_refs=False,
+        prompt_prefix=None,
+    ),
+}
+
+
+def _resize_image_bytes(image_bytes: bytes, width: int, height: int) -> bytes:
+    """Resize an image to exact dimensions, returning PNG bytes.
+
+    LTX guide images must match the latent dimensions; the official template
+    does this with ResizeImageMaskNode ("scale dimensions"), which we replicate
+    Python-side to keep the committed workflow graph minimal.
+    """
+    img = Image.open(io.BytesIO(image_bytes))
+    if img.size != (width, height):
+        img = img.convert("RGB").resize((width, height), Image.LANCZOS)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
 
 
 # ---------------------------------------------------------------------------
@@ -85,7 +200,7 @@ def find_video_output(
                         )
         return None
 
-    # Pattern 1: look for SaveVideo node 108 specifically
+    # Pattern 1: look for SaveVideo node 108 specifically (WAN template)
     node_108 = outputs.get("108", {})
     if isinstance(node_108, dict):
         result = _extract_video(node_108)
@@ -141,39 +256,53 @@ class ComfyUIVideoAdapter:
         seed: int,
         shot_index: int,
         video_model: str,
+        duration_seconds: int = 5,
+        audio_enabled: bool = False,
     ) -> str:
-        """Upload assets, build workflow, and queue prompt.
+        """Upload assets, build the model-specific workflow, and queue prompt.
 
         Args:
             video_prompt: Motion/shot prompt text.
             start_frame_bytes: PNG bytes for the start keyframe.
-            end_frame_bytes: PNG bytes for the end keyframe (None for I2V).
-            char_ref_bytes: List of character reference image bytes (0-2).
-                TODO: Not yet wired into WAN 2.2 I2V workflow — see docs/camera-pan.md Action 3.
+            end_frame_bytes: PNG bytes for the end keyframe; None falls back
+                to first-frame-only generation (even on FLF2V models).
+            char_ref_bytes: Character reference image bytes (0-2). Only wired
+                for models with supports_char_refs (QC passthrough on
+                wan-2.2-flf2v).
             aspect_ratio: "16:9" or "9:16".
             seed: Random seed for reproducibility.
             shot_index: Shot number (for filename prefixes).
-            video_model: Model ID (e.g. "wan-2.2-i2v").
+            video_model: Model ID; must be a key of COMFY_VIDEO_SPECS.
+            duration_seconds: Requested clip duration (ignored by WAN models,
+                which always produce ~5s).
+            audio_enabled: Generate audio (models with supports_audio only).
 
         Returns:
             Operation ID in format "comfyui:{prompt_id}".
         """
-        # Upload start keyframe
-        start_fn = await self.client.upload_image(
-            start_frame_bytes, f"shot_{shot_index}_start.png"
-        )
-        logger.info("Shot %d: uploaded start keyframe as %s", shot_index, start_fn)
+        spec = COMFY_VIDEO_SPECS.get(video_model)
+        if spec is None:
+            raise ValueError(
+                f"Unknown ComfyUI video model {video_model!r}. "
+                f"Known: {sorted(COMFY_VIDEO_SPECS)}"
+            )
 
-        width, height = wan_resolution(aspect_ratio)
+        if spec.prompt_prefix:
+            video_prompt = spec.prompt_prefix + video_prompt
 
-        workflow = build_wan22_i2v_workflow(
-            prompt=video_prompt,
-            negative_prompt=WAN_I2V_NEGATIVE_PROMPT,
-            image_filename=start_fn,
-            width=width,
-            height=height,
-            length=81,  # 81 frames @ 16fps ≈ 5s
+        use_end_frame = end_frame_bytes is not None and spec.supports_end_frame
+        workflow = await self._build_workflow(
+            spec=spec,
+            video_model=video_model,
+            video_prompt=video_prompt,
+            start_frame_bytes=start_frame_bytes,
+            end_frame_bytes=end_frame_bytes if use_end_frame else None,
+            char_ref_bytes=char_ref_bytes if spec.supports_char_refs else [],
+            aspect_ratio=aspect_ratio,
             seed=seed,
+            shot_index=shot_index,
+            duration_seconds=duration_seconds,
+            audio_enabled=audio_enabled and spec.supports_audio,
         )
 
         # Log what we injected into the workflow for diagnostics
@@ -182,6 +311,125 @@ class ComfyUIVideoAdapter:
         prompt_id = await self.client.queue_prompt(workflow)
         logger.info("Shot %d: ComfyUI prompt queued: %s", shot_index, prompt_id)
         return f"comfyui:{prompt_id}"
+
+    async def _build_workflow(
+        self,
+        *,
+        spec: ComfyVideoModelSpec,
+        video_model: str,
+        video_prompt: str,
+        start_frame_bytes: bytes,
+        end_frame_bytes: Optional[bytes],
+        char_ref_bytes: list[bytes],
+        aspect_ratio: str,
+        seed: int,
+        shot_index: int,
+        duration_seconds: int,
+        audio_enabled: bool,
+    ) -> dict:
+        """Upload inputs and build the API workflow for one model."""
+        if video_model in ("wan-2.2-i2v", "wan-2.2-flf2v"):
+            width, height = wan_resolution(aspect_ratio)
+            start_fn = await self.client.upload_image(
+                start_frame_bytes, f"shot_{shot_index}_start.png"
+            )
+            logger.info("Shot %d: uploaded start keyframe as %s", shot_index, start_fn)
+
+            if video_model == "wan-2.2-flf2v" and end_frame_bytes is not None:
+                end_fn = await self.client.upload_image(
+                    end_frame_bytes, f"shot_{shot_index}_end.png"
+                )
+                char_fns: list[Optional[str]] = [None, None]
+                for i, ref in enumerate(char_ref_bytes[:2]):
+                    char_fns[i] = await self.client.upload_image(
+                        ref, f"shot_{shot_index}_charref_{i + 1}.png"
+                    )
+                return build_wan22_flf2v_workflow(
+                    prompt=video_prompt,
+                    start_keyframe_filename=start_fn,
+                    end_keyframe_filename=end_fn,
+                    char_ref_01_filename=char_fns[0],
+                    char_ref_02_filename=char_fns[1],
+                    width=width,
+                    height=height,
+                    length=81,
+                    seed=seed,
+                )
+
+            if video_model == "wan-2.2-flf2v":
+                logger.warning(
+                    "Shot %d: wan-2.2-flf2v has no end keyframe — "
+                    "falling back to I2V workflow",
+                    shot_index,
+                )
+            return build_wan22_i2v_workflow(
+                prompt=video_prompt,
+                negative_prompt=WAN_I2V_NEGATIVE_PROMPT,
+                image_filename=start_fn,
+                width=width,
+                height=height,
+                length=81,
+                seed=seed,
+            )
+
+        if video_model == "ltx-2.3-flf2v":
+            width, height = ltx_resolution(aspect_ratio)
+            # LTX guide images must match the latent dimensions
+            start_fn = await self.client.upload_image(
+                _resize_image_bytes(start_frame_bytes, width, height),
+                f"shot_{shot_index}_start.png",
+            )
+            end_fn = None
+            if end_frame_bytes is not None:
+                end_fn = await self.client.upload_image(
+                    _resize_image_bytes(end_frame_bytes, width, height),
+                    f"shot_{shot_index}_end.png",
+                )
+            else:
+                logger.warning(
+                    "Shot %d: ltx-2.3-flf2v has no end keyframe — "
+                    "using first-frame guide only",
+                    shot_index,
+                )
+            return build_ltx23_flf2v_workflow(
+                prompt=video_prompt,
+                negative_prompt=LTX_NEGATIVE_PROMPT,
+                start_keyframe_filename=start_fn,
+                end_keyframe_filename=end_fn,
+                width=width,
+                height=height,
+                frames=ltx_frames_for_duration(duration_seconds),
+                seed=seed,
+                generate_audio=audio_enabled,
+            )
+
+        if video_model == "seedance-2.0-flf2v":
+            start_fn = await self.client.upload_image(
+                start_frame_bytes, f"shot_{shot_index}_start.png"
+            )
+            end_fn = None
+            if end_frame_bytes is not None:
+                end_fn = await self.client.upload_image(
+                    end_frame_bytes, f"shot_{shot_index}_end.png"
+                )
+            else:
+                logger.warning(
+                    "Shot %d: seedance-2.0-flf2v has no end keyframe — "
+                    "first-frame-only generation",
+                    shot_index,
+                )
+            return build_seedance2_flf2v_workflow(
+                prompt=video_prompt,
+                first_frame_filename=start_fn,
+                last_frame_filename=end_fn,
+                duration=max(4, min(15, duration_seconds)),
+                resolution="720p",
+                aspect_ratio=aspect_ratio,
+                seed=seed,
+                generate_audio=audio_enabled,
+            )
+
+        raise ValueError(f"No workflow builder for ComfyUI model {video_model!r}")
 
     async def poll(self, operation_id: str) -> tuple[str, Optional[str]]:
         """Check job status with normalized status values.
@@ -210,11 +458,24 @@ class ComfyUIVideoAdapter:
             )
             return "running", None
 
-    async def download(self, operation_id: str) -> tuple[bytes, float]:
+    async def download(
+        self,
+        operation_id: str,
+        *,
+        video_model: str = "wan-2.2-i2v",
+        duration_seconds: int = 5,
+    ) -> tuple[bytes, float]:
         """Download the completed video from ComfyUI.
 
         Fetches execution history, locates the video output file,
         and downloads it.
+
+        Args:
+            operation_id: "comfyui:{prompt_id}" operation ID.
+            video_model: Model that produced the job (drives the reported
+                duration). Defaults preserve pre-spec behavior for in-flight
+                jobs submitted before a deploy.
+            duration_seconds: Requested clip duration.
 
         Returns:
             (video_bytes, duration_seconds)
@@ -240,7 +501,10 @@ class ComfyUIVideoAdapter:
             filename, subfolder=subfolder,
         )
 
-        duration = 81 / 16.0  # 81 frames @ 16fps ≈ 5.06s
+        spec = COMFY_VIDEO_SPECS.get(video_model)
+        duration = (
+            spec.clip_duration(duration_seconds) if spec else 81 / 16.0
+        )
         logger.info(
             "ComfyUI %s: downloaded %d bytes (%.1fs duration)",
             prompt_id, len(video_bytes), duration,
@@ -291,7 +555,8 @@ class ComfyUIVideoAdapter:
                 if video_result else None
             )
 
-            # Submitted workflow summary
+            # Submitted workflow summary (WAN node IDs; other models degrade
+            # gracefully to "(not found)" placeholders)
             prompt_wf = prompt_data.get("prompt", {}).get("prompt", {})
             if prompt_wf:
                 # Prompt text (node 93)
@@ -332,36 +597,49 @@ class ComfyUIVideoAdapter:
 # Logging helpers
 # ---------------------------------------------------------------------------
 
+def _summarize_workflow(workflow: dict) -> dict:
+    """Extract loggable key parameters from any of our video workflows."""
+    summary: dict = {}
+    for node_id, node in workflow.items():
+        ct = node.get("class_type", "")
+        inputs = node.get("inputs", {})
+        if ct == "CLIPTextEncode" or ct == "TextEncodeQwenImageEditPlus":
+            key = "positive_prompt" if "positive_prompt" not in summary else "negative_prompt"
+            summary[key] = str(inputs.get("text", inputs.get("prompt", "")))
+        elif ct == "LoadImage":
+            summary.setdefault("images", []).append(inputs.get("image", ""))
+        elif ct in ("WanFirstLastFrameToVideo", "WanImageToVideo", "EmptyLTXVLatentVideo"):
+            summary["dimensions"] = (
+                f"{inputs.get('width', 0)}x{inputs.get('height', 0)}, "
+                f"{inputs.get('length', 0)} frames"
+            )
+        elif ct == "ByteDance2FirstLastFrameNode":
+            summary["positive_prompt"] = str(inputs.get("model.prompt", ""))
+            summary["dimensions"] = (
+                f"{inputs.get('model.resolution')} {inputs.get('model.ratio')} "
+                f"{inputs.get('model.duration')}s audio={inputs.get('model.generate_audio')}"
+            )
+            summary["seed"] = inputs.get("seed")
+        elif ct in ("KSamplerAdvanced", "RandomNoise"):
+            summary["seed"] = inputs.get("noise_seed", summary.get("seed"))
+    return summary
+
+
 def _log_workflow_injection(
     workflow: dict, shot_index: int, video_model: str
 ) -> None:
     """Log key parameters injected into a ComfyUI workflow before submission."""
-    # Positive prompt (node 93)
-    n93_text = workflow.get("93", {}).get("inputs", {}).get("text", "")
-    # Negative prompt (node 89)
-    n89_text = workflow.get("89", {}).get("inputs", {}).get("text", "")
-    # Start image (node 97)
-    n97_image = workflow.get("97", {}).get("inputs", {}).get("image", "")
-    # End image (node 200, FLF2V only)
-    n200_image = workflow.get("200", {}).get("inputs", {}).get("image", "")
-    # Dimensions (node 98)
-    n98 = workflow.get("98", {}).get("inputs", {})
-    # Seed (node 86)
-    n86_seed = workflow.get("86", {}).get("inputs", {}).get("noise_seed", "")
-
+    s = _summarize_workflow(workflow)
+    pos = s.get("positive_prompt", "")
     logger.info(
         "Shot %d [%s] workflow injection:\n"
         "  positive_prompt: %.120s%s\n"
-        "  negative_prompt: %.80s%s\n"
-        "  start_image: %s\n"
-        "  end_image: %s\n"
-        "  dimensions: %dx%d, %d frames\n"
+        "  images: %s\n"
+        "  dimensions: %s\n"
         "  seed: %s",
         shot_index, video_model,
-        n93_text, "..." if len(n93_text) > 120 else "",
-        n89_text, "..." if len(n89_text) > 80 else "",
-        n97_image or "(none)",
-        n200_image or "(none — I2V mode)",
-        n98.get("width", 0), n98.get("height", 0), n98.get("length", 0),
-        n86_seed,
+        pos, "..." if len(pos) > 120 else "",
+        s.get("images", []),
+        s.get("dimensions", "(n/a)"),
+        s.get("seed", "(n/a)"),
     )

--- a/backend/vidpipe/services/comfyui_client.py
+++ b/backend/vidpipe/services/comfyui_client.py
@@ -141,21 +141,39 @@ def _convert_app_to_api(app_workflow: dict) -> dict:
     return api_workflow
 
 
-# Module-level cache for the converted API template
+# Packaged API-format template (pre-converted from docs/video_wan2_2_14B_i2v.json
+# — the docs/ copy is NOT shipped in the Docker image, so the converted graph
+# is committed alongside the package).
+_WAN_FLF2V_TEMPLATE_PATH = (
+    Path(__file__).resolve().parent / "comfyui_templates" / "wan-flf2v.json"
+)
+
+# Module-level cache for the API template
 _cached_api_template: Optional[dict] = None
 
 
 def _load_api_template() -> dict:
-    """Load and convert the workflow JSON template, caching the result."""
+    """Load the Wan FLF2V API-format workflow template, caching the result.
+
+    Prefers the packaged pre-converted template; falls back to converting the
+    app-format docs/ copy for dev checkouts where it exists.
+    """
     global _cached_api_template
     if _cached_api_template is None:
-        with open(_WORKFLOW_TEMPLATE_PATH) as f:
-            app_workflow = json.load(f)
-        _cached_api_template = _convert_app_to_api(app_workflow)
-        logger.info(
-            "Loaded and converted ComfyUI workflow template from %s",
-            _WORKFLOW_TEMPLATE_PATH,
-        )
+        if _WAN_FLF2V_TEMPLATE_PATH.exists():
+            with open(_WAN_FLF2V_TEMPLATE_PATH) as f:
+                _cached_api_template = json.load(f)
+            logger.info(
+                "Loaded Wan FLF2V template from %s", _WAN_FLF2V_TEMPLATE_PATH,
+            )
+        else:
+            with open(_WORKFLOW_TEMPLATE_PATH) as f:
+                app_workflow = json.load(f)
+            _cached_api_template = _convert_app_to_api(app_workflow)
+            logger.info(
+                "Loaded and converted ComfyUI workflow template from %s",
+                _WORKFLOW_TEMPLATE_PATH,
+            )
     return _cached_api_template
 
 

--- a/backend/vidpipe/services/comfyui_client.py
+++ b/backend/vidpipe/services/comfyui_client.py
@@ -219,7 +219,7 @@ def build_wan22_flf2v_workflow(
     workflow["98"]["inputs"]["width"] = width
     workflow["98"]["inputs"]["height"] = height
     workflow["98"]["inputs"]["length"] = length
-    workflow["86"]["inputs"]["noise_seed"] = seed
+    workflow["86"]["inputs"]["noise_seed"] = int(seed or 0)  # never None → ComfyUI 400
 
     # Character reference passthroughs (QC only) —
     # inject filename if present, remove nodes entirely if not.
@@ -780,7 +780,7 @@ def build_flux_txt2img_workflow(
     workflow["7"]["inputs"]["text"] = negative_prompt
 
     # Inject seed and dimensions
-    workflow["3"]["inputs"]["seed"] = seed
+    workflow["3"]["inputs"]["seed"] = int(seed or 0)  # never None → ComfyUI 400
     workflow["5"]["inputs"]["width"] = width
     workflow["5"]["inputs"]["height"] = height
 
@@ -882,7 +882,7 @@ def build_wan22_i2v_workflow(
     workflow["98"]["inputs"]["width"] = width
     workflow["98"]["inputs"]["height"] = height
     workflow["98"]["inputs"]["length"] = length
-    workflow["86"]["inputs"]["noise_seed"] = seed
+    workflow["86"]["inputs"]["noise_seed"] = int(seed or 0)  # never None → ComfyUI 400
 
     return workflow
 
@@ -1081,7 +1081,7 @@ def build_flux2_klein_workflow(
     workflow = copy.deepcopy(_load_flux2_klein_template())
 
     workflow["74"]["inputs"]["text"] = prompt
-    workflow["73"]["inputs"]["noise_seed"] = seed
+    workflow["73"]["inputs"]["noise_seed"] = int(seed or 0)  # never None → ComfyUI 400
     workflow["66"]["inputs"]["width"] = width
     workflow["66"]["inputs"]["height"] = height
     workflow["67"]["inputs"]["width"] = width
@@ -1206,7 +1206,7 @@ def build_ltx23_flf2v_workflow(
     workflow["16"]["inputs"]["height"] = height
     workflow["16"]["inputs"]["length"] = frames
     workflow["19"]["inputs"]["frames_number"] = frames
-    workflow["21"]["inputs"]["noise_seed"] = seed
+    workflow["21"]["inputs"]["noise_seed"] = int(seed or 0)  # never None → ComfyUI 400
 
     if end_keyframe_filename is not None:
         workflow["13"]["inputs"]["image"] = end_keyframe_filename

--- a/backend/vidpipe/services/comfyui_client.py
+++ b/backend/vidpipe/services/comfyui_client.py
@@ -1091,6 +1091,224 @@ def build_flux2_klein_workflow(
     return workflow
 
 
+# ---------------------------------------------------------------------------
+# LTX-2.3 FLF2V workflow builder + resolution mapping
+# ---------------------------------------------------------------------------
+
+LTX_FPS = 25
+
+_LTX_RESOLUTIONS: dict[str, tuple[int, int]] = {
+    "16:9": (1280, 720),
+    "9:16": (720, 1280),
+}
+
+
+def ltx_resolution(aspect_ratio: str) -> tuple[int, int]:
+    """Map aspect ratio string to LTX-2.3 native resolution (width, height)."""
+    if aspect_ratio not in _LTX_RESOLUTIONS:
+        raise ValueError(
+            f"Unsupported aspect ratio for LTX-2.3: {aspect_ratio}. "
+            f"Supported: {list(_LTX_RESOLUTIONS.keys())}"
+        )
+    return _LTX_RESOLUTIONS[aspect_ratio]
+
+
+def ltx_frames_for_duration(seconds: int) -> int:
+    """Frame count for an LTX clip of the given duration (template math: s*fps+1)."""
+    return seconds * LTX_FPS + 1
+
+
+_LTX_FLF2V_TEMPLATE_PATH = (
+    Path(__file__).resolve().parent / "comfyui_templates" / "ltx-flf2v.json"
+)
+
+_cached_ltx_flf2v_template: Optional[dict] = None
+
+
+def _load_ltx_flf2v_template() -> dict:
+    """Load the LTX-2.3 FLF2V API-format workflow template, caching the result."""
+    global _cached_ltx_flf2v_template
+    if _cached_ltx_flf2v_template is None:
+        with open(_LTX_FLF2V_TEMPLATE_PATH) as f:
+            _cached_ltx_flf2v_template = json.load(f)
+        logger.info("Loaded LTX FLF2V template from %s", _LTX_FLF2V_TEMPLATE_PATH)
+    return _cached_ltx_flf2v_template
+
+
+def build_ltx23_flf2v_workflow(
+    *,
+    prompt: str,
+    negative_prompt: str,
+    start_keyframe_filename: str,
+    end_keyframe_filename: Optional[str] = None,
+    width: int = 1280,
+    height: int = 720,
+    frames: int = 126,
+    seed: int = 0,
+    generate_audio: bool = True,
+) -> dict:
+    """Build ComfyUI API-format workflow for LTX-2.3 first-last-frame to video.
+
+    Based on the official video_ltx2_3_flf2v template (22B distilled
+    checkpoint, joint audio+video latent, dual LTXVAddGuide conditioning at
+    frame 0 and frame -1, audio muxed via CreateVideo).
+
+    Keyframe images must be pre-resized to (width, height) before upload —
+    the committed template omits the ResizeImageMaskNode plumbing.
+
+    Injects runtime parameters into the cached template:
+    - Node 4/5: positive/negative prompt
+    - Node 10/13: start/end LoadImage filenames
+    - Node 16/19: latent dimensions + frame counts
+    - Node 21: RandomNoise seed
+    - End-frame guide (node 18) spliced out when end_keyframe_filename is None
+    - Audio input dropped from CreateVideo when generate_audio is False
+
+    Args:
+        prompt: Motion/shot prompt (can include a "Music:"/"Audio:" hint).
+        negative_prompt: Negative prompt text.
+        start_keyframe_filename: Uploaded filename for the start frame.
+        end_keyframe_filename: Uploaded filename for the end frame, or None
+            for plain image-to-video.
+        width: Video width (default 1280 for 16:9).
+        height: Video height (default 720 for 16:9).
+        frames: Frame count (use ltx_frames_for_duration; default 126 ≈ 5s @ 25fps).
+        seed: Random seed.
+        generate_audio: Mux generated audio into the output video.
+
+    Returns:
+        ComfyUI API-format prompt dict (node_id -> node_config).
+    """
+    workflow = copy.deepcopy(_load_ltx_flf2v_template())
+
+    workflow["4"]["inputs"]["text"] = prompt
+    workflow["5"]["inputs"]["text"] = negative_prompt
+    workflow["10"]["inputs"]["image"] = start_keyframe_filename
+    workflow["16"]["inputs"]["width"] = width
+    workflow["16"]["inputs"]["height"] = height
+    workflow["16"]["inputs"]["length"] = frames
+    workflow["19"]["inputs"]["frames_number"] = frames
+    workflow["21"]["inputs"]["noise_seed"] = seed
+
+    if end_keyframe_filename is not None:
+        workflow["13"]["inputs"]["image"] = end_keyframe_filename
+    else:
+        # Splice out the end-frame guide chain: downstream consumers of the
+        # last guide (node 18) rewire to the first guide (node 17).
+        workflow.pop("13", None)
+        workflow.pop("15", None)
+        workflow.pop("18", None)
+        workflow["20"]["inputs"]["video_latent"] = ["17", 2]
+        workflow["22"]["inputs"]["positive"] = ["17", 0]
+        workflow["22"]["inputs"]["negative"] = ["17", 1]
+        workflow["27"]["inputs"]["positive"] = ["17", 0]
+        workflow["27"]["inputs"]["negative"] = ["17", 1]
+
+    if not generate_audio:
+        # Silent output: drop the audio link from CreateVideo and the now
+        # unused audio decode node (the joint AV latent itself is structural).
+        workflow["30"]["inputs"].pop("audio", None)
+        workflow.pop("29", None)
+
+    return workflow
+
+
+# ---------------------------------------------------------------------------
+# Seedance 2.0 FLF2V workflow builder (ByteDance partner API node)
+# ---------------------------------------------------------------------------
+
+_SEEDANCE_RATIOS = {"16:9", "4:3", "1:1", "3:4", "9:16", "21:9", "adaptive"}
+
+_SEEDANCE_FLF2V_TEMPLATE_PATH = (
+    Path(__file__).resolve().parent / "comfyui_templates" / "seedance-flf2v.json"
+)
+
+_cached_seedance_flf2v_template: Optional[dict] = None
+
+
+def _load_seedance_flf2v_template() -> dict:
+    """Load the Seedance 2.0 FLF2V API-format workflow template, caching the result."""
+    global _cached_seedance_flf2v_template
+    if _cached_seedance_flf2v_template is None:
+        with open(_SEEDANCE_FLF2V_TEMPLATE_PATH) as f:
+            _cached_seedance_flf2v_template = json.load(f)
+        logger.info(
+            "Loaded Seedance FLF2V template from %s", _SEEDANCE_FLF2V_TEMPLATE_PATH
+        )
+    return _cached_seedance_flf2v_template
+
+
+def build_seedance2_flf2v_workflow(
+    *,
+    prompt: str,
+    first_frame_filename: str,
+    last_frame_filename: Optional[str] = None,
+    duration: int = 5,
+    resolution: str = "720p",
+    aspect_ratio: str = "16:9",
+    seed: int = 0,
+    generate_audio: bool = True,
+    watermark: bool = False,
+) -> dict:
+    """Build ComfyUI API-format workflow for Seedance 2.0 first-last-frame video.
+
+    Uses the ByteDance2FirstLastFrameNode partner API node (paid, metered in
+    Comfy credits). The node's DynamicCombo "model" input serializes nested
+    fields as dotted paths (model.prompt, model.resolution, ...).
+
+    Injects runtime parameters into the cached template:
+    - Node 1/2: first/last LoadImage filenames (node 2 pruned when no last frame)
+    - Node 3: prompt, resolution, ratio, duration, generate_audio, seed, watermark
+
+    Args:
+        prompt: Motion/shot prompt text.
+        first_frame_filename: Uploaded filename for the first frame.
+        last_frame_filename: Uploaded filename for the last frame, or None
+            for first-frame-only generation.
+        duration: Clip duration in seconds (4-15).
+        resolution: "480p", "720p", or "1080p".
+        aspect_ratio: One of 16:9, 4:3, 1:1, 3:4, 9:16, 21:9, adaptive.
+        seed: Random seed (0-2147483647; results are non-deterministic anyway).
+        generate_audio: Generate synchronized audio.
+        watermark: Add a visible watermark.
+
+    Returns:
+        ComfyUI API-format prompt dict (node_id -> node_config).
+
+    Raises:
+        ValueError: On out-of-range duration or unsupported aspect ratio.
+    """
+    if not 4 <= duration <= 15:
+        raise ValueError(
+            f"Seedance 2.0 duration must be 4-15 seconds, got {duration}"
+        )
+    if aspect_ratio not in _SEEDANCE_RATIOS:
+        raise ValueError(
+            f"Unsupported aspect ratio for Seedance 2.0: {aspect_ratio}. "
+            f"Supported: {sorted(_SEEDANCE_RATIOS)}"
+        )
+
+    workflow = copy.deepcopy(_load_seedance_flf2v_template())
+
+    node = workflow["3"]["inputs"]
+    node["model.prompt"] = prompt
+    node["model.resolution"] = resolution
+    node["model.ratio"] = aspect_ratio
+    node["model.duration"] = duration
+    node["model.generate_audio"] = generate_audio
+    node["seed"] = int(seed) % 2147483648
+    node["watermark"] = watermark
+
+    workflow["1"]["inputs"]["image"] = first_frame_filename
+    if last_frame_filename is not None:
+        workflow["2"]["inputs"]["image"] = last_frame_filename
+    else:
+        workflow.pop("2", None)
+        node.pop("last_frame", None)
+
+    return workflow
+
+
 async def close_comfyui_client() -> None:
     """Close the singleton ComfyUIClient (for app shutdown)."""
     global _comfyui_client

--- a/backend/vidpipe/services/comfyui_client.py
+++ b/backend/vidpipe/services/comfyui_client.py
@@ -93,7 +93,7 @@ _WIDGET_NAMES: dict[str, list[str]] = {
         "start_at_step", "end_at_step", "return_with_leftover_noise",
     ],
     "VAEDecode": [],
-    "CreateVideo": ["frame_rate"],
+    "CreateVideo": ["fps"],
     "SaveVideo": ["filename_prefix", "format", "codec"],
     "ImageFromBatch": ["batch_index", "length"],
     "SaveImage": ["filename_prefix"],

--- a/backend/vidpipe/services/comfyui_client.py
+++ b/backend/vidpipe/services/comfyui_client.py
@@ -471,6 +471,13 @@ async def get_comfyui_client(
 # Qwen txt2img workflow builder + image output extractor
 # ---------------------------------------------------------------------------
 
+# Qwen-Image native resolutions (~1.7MP budget) per aspect ratio
+_QWEN_RESOLUTIONS: dict[str, tuple[int, int]] = {
+    "16:9": (1664, 928),
+    "9:16": (928, 1664),
+    "1:1": (1328, 1328),
+}
+
 _QWEN_TEMPLATE_PATH = (
     Path(__file__).resolve().parent / "comfyui_templates" / "qwen-txt2img.json"
 )
@@ -858,6 +865,228 @@ def build_wan22_i2v_workflow(
     workflow["98"]["inputs"]["height"] = height
     workflow["98"]["inputs"]["length"] = length
     workflow["86"]["inputs"]["noise_seed"] = seed
+
+    return workflow
+
+
+# ---------------------------------------------------------------------------
+# Qwen Image Edit 2509 (multi-reference) workflow builder
+# ---------------------------------------------------------------------------
+
+_QWEN_EDIT_2509_TEMPLATE_PATH = (
+    Path(__file__).resolve().parent / "comfyui_templates" / "qwen-edit-2509.json"
+)
+
+_cached_qwen_edit_2509_template: Optional[dict] = None
+
+
+def _load_qwen_edit_2509_template() -> dict:
+    """Load the Qwen Image Edit 2509 API-format workflow template, caching the result."""
+    global _cached_qwen_edit_2509_template
+    if _cached_qwen_edit_2509_template is None:
+        with open(_QWEN_EDIT_2509_TEMPLATE_PATH) as f:
+            _cached_qwen_edit_2509_template = json.load(f)
+        logger.info("Loaded Qwen Edit 2509 template from %s", _QWEN_EDIT_2509_TEMPLATE_PATH)
+    return _cached_qwen_edit_2509_template
+
+
+def build_qwen_edit_2509_workflow(
+    *,
+    prompt: str,
+    image_filenames: list[str],
+    negative_prompt: str = "",
+    seed: int | None = 0,
+    output_width: Optional[int] = None,
+    output_height: Optional[int] = None,
+) -> dict:
+    """Build ComfyUI API-format workflow for Qwen Image Edit 2509 (multi-ref).
+
+    Accepts 1-3 input images via TextEncodeQwenImageEditPlus (image1-3).
+    Two output-size modes (the template KSampler runs at denoise 1.0, so the
+    latent_image input only determines output dimensions, not content):
+
+    - Edit mode (default): output dimensions follow image1 — used for
+      end-keyframe generation where image1 is the start frame.
+    - Generation mode (output_width/output_height given): output uses an
+      EmptySD3LatentImage at the requested dimensions — used for start-frame
+      composition from reference images at the scene aspect ratio.
+
+    Injects runtime parameters into the cached template:
+    - Node 110/111: positive/negative prompt + image1-3 references
+    - Node 10/11/12: LoadImage filenames (unused ref nodes pruned)
+    - Node 3: KSampler seed (+ latent_image source per mode)
+    - Node 107: EmptySD3LatentImage dimensions (generation mode only)
+
+    Args:
+        prompt: Edit/composition instruction.
+        image_filenames: 1-3 uploaded server-side filenames. The first is
+            image1 (drives output size in edit mode).
+        negative_prompt: Negative prompt text (default empty).
+        seed: Random seed for reproducibility.
+        output_width: Explicit output width (enables generation mode).
+        output_height: Explicit output height (enables generation mode).
+
+    Returns:
+        ComfyUI API-format prompt dict (node_id -> node_config).
+
+    Raises:
+        ValueError: If image_filenames is empty or has more than 3 entries.
+    """
+    if not image_filenames:
+        raise ValueError("qwen-image-edit-2509 requires at least one input image")
+    if len(image_filenames) > 3:
+        raise ValueError(
+            f"qwen-image-edit-2509 supports at most 3 input images, got {len(image_filenames)}"
+        )
+
+    workflow = copy.deepcopy(_load_qwen_edit_2509_template())
+
+    workflow["110"]["inputs"]["prompt"] = prompt
+    workflow["111"]["inputs"]["prompt"] = negative_prompt
+    workflow["3"]["inputs"]["seed"] = int(seed or 0)
+
+    # Map filenames to LoadImage nodes 10/11/12; prune unused refs and drop
+    # the corresponding imageN inputs from both text-encode nodes.
+    ref_nodes = ["10", "11", "12"]
+    image_keys = ["image1", "image2", "image3"]
+    for i, node_id in enumerate(ref_nodes):
+        if i < len(image_filenames):
+            workflow[node_id]["inputs"]["image"] = image_filenames[i]
+        else:
+            workflow.pop(node_id, None)
+            workflow["110"]["inputs"].pop(image_keys[i], None)
+            workflow["111"]["inputs"].pop(image_keys[i], None)
+
+    generation_mode = output_width is not None and output_height is not None
+    if generation_mode:
+        workflow["107"]["inputs"]["width"] = output_width
+        workflow["107"]["inputs"]["height"] = output_height
+        workflow["3"]["inputs"]["latent_image"] = ["107", 0]
+    else:
+        # Edit mode: latent follows image1 (template default); drop the
+        # unused empty-latent node.
+        workflow.pop("107", None)
+
+    return workflow
+
+
+# ---------------------------------------------------------------------------
+# FLUX.2 Klein workflow builder + resolution mapping
+# ---------------------------------------------------------------------------
+
+_FLUX2_RESOLUTIONS: dict[str, tuple[int, int]] = {
+    "16:9": (1344, 768),
+    "9:16": (768, 1344),
+    "1:1": (1024, 1024),
+}
+
+
+def flux2_resolution(aspect_ratio: str) -> tuple[int, int]:
+    """Map aspect ratio string to FLUX.2 Klein native resolution (width, height)."""
+    if aspect_ratio not in _FLUX2_RESOLUTIONS:
+        raise ValueError(
+            f"Unsupported aspect ratio for FLUX.2 Klein: {aspect_ratio}. "
+            f"Supported: {list(_FLUX2_RESOLUTIONS.keys())}"
+        )
+    return _FLUX2_RESOLUTIONS[aspect_ratio]
+
+
+_FLUX2_KLEIN_TEMPLATE_PATH = (
+    Path(__file__).resolve().parent / "comfyui_templates" / "flux2-klein.json"
+)
+
+_cached_flux2_klein_template: Optional[dict] = None
+
+
+def _load_flux2_klein_template() -> dict:
+    """Load the FLUX.2 Klein API-format workflow template, caching the result."""
+    global _cached_flux2_klein_template
+    if _cached_flux2_klein_template is None:
+        with open(_FLUX2_KLEIN_TEMPLATE_PATH) as f:
+            _cached_flux2_klein_template = json.load(f)
+        logger.info("Loaded FLUX.2 Klein template from %s", _FLUX2_KLEIN_TEMPLATE_PATH)
+    return _cached_flux2_klein_template
+
+
+# Per-ref-slot node IDs: (LoadImage, ImageScaleToTotalPixels, VAEEncode,
+# positive ReferenceLatent, negative ReferenceLatent)
+_FLUX2_REF_SLOTS: list[tuple[str, str, str, str, str]] = [
+    ("20", "30", "40", "50", "60"),
+    ("21", "31", "41", "51", "61"),
+    ("22", "32", "42", "52", "62"),
+    ("23", "33", "43", "53", "63"),
+]
+
+
+def build_flux2_klein_workflow(
+    *,
+    prompt: str,
+    width: int = 1024,
+    height: int = 1024,
+    seed: int = 0,
+    reference_image_filenames: Optional[list[str]] = None,
+) -> dict:
+    """Build ComfyUI API-format workflow for FLUX.2 Klein 4B (distilled).
+
+    Supports 0-4 reference images. References are chained ReferenceLatent
+    conditioning on both the positive and negative (zeroed) branches, per the
+    official image_flux2_klein_image_edit_4b_distilled template. With zero
+    references the graph reduces to plain text-to-image.
+
+    Injects runtime parameters into the cached template:
+    - Node 74: positive prompt text
+    - Node 73: RandomNoise seed
+    - Node 66/67: latent + scheduler dimensions
+    - Nodes 20-23: reference LoadImage filenames (unused slots pruned)
+    - Node 76: CFGGuider conditioning rewired to the last surviving
+      ReferenceLatent in each chain (or directly to the encoders at 0 refs)
+
+    Args:
+        prompt: Positive prompt text.
+        width: Output width in pixels (multiple of 16).
+        height: Output height in pixels (multiple of 16).
+        seed: Random seed for reproducibility.
+        reference_image_filenames: Up to 4 uploaded server-side filenames.
+
+    Returns:
+        ComfyUI API-format prompt dict (node_id -> node_config).
+
+    Raises:
+        ValueError: If more than 4 reference images are provided.
+    """
+    refs = reference_image_filenames or []
+    if len(refs) > 4:
+        raise ValueError(
+            f"flux-2-klein supports at most 4 reference images, got {len(refs)}"
+        )
+
+    workflow = copy.deepcopy(_load_flux2_klein_template())
+
+    workflow["74"]["inputs"]["text"] = prompt
+    workflow["73"]["inputs"]["noise_seed"] = seed
+    workflow["66"]["inputs"]["width"] = width
+    workflow["66"]["inputs"]["height"] = height
+    workflow["67"]["inputs"]["width"] = width
+    workflow["67"]["inputs"]["height"] = height
+
+    # Fill used ref slots, prune unused ones.
+    for i, (load_id, scale_id, encode_id, pos_rl_id, neg_rl_id) in enumerate(
+        _FLUX2_REF_SLOTS
+    ):
+        if i < len(refs):
+            workflow[load_id]["inputs"]["image"] = refs[i]
+        else:
+            for node_id in (load_id, scale_id, encode_id, pos_rl_id, neg_rl_id):
+                workflow.pop(node_id, None)
+
+    # Rewire CFGGuider conditioning to the end of the surviving chains.
+    if refs:
+        last_slot = _FLUX2_REF_SLOTS[len(refs) - 1]
+        workflow["76"]["inputs"]["positive"] = [last_slot[3], 0]
+        workflow["76"]["inputs"]["negative"] = [last_slot[4], 0]
+    else:
+        workflow["76"]["inputs"]["positive"] = ["74", 0]
+        workflow["76"]["inputs"]["negative"] = ["82", 0]
 
     return workflow
 

--- a/backend/vidpipe/services/comfyui_templates/flux2-klein.json
+++ b/backend/vidpipe/services/comfyui_templates/flux2-klein.json
@@ -1,0 +1,463 @@
+{
+  "70": {
+    "inputs": {
+      "unet_name": "flux-2-klein-4b-fp8.safetensors",
+      "weight_dtype": "default"
+    },
+    "class_type": "UNETLoader",
+    "_meta": {
+      "title": "Load Diffusion Model"
+    }
+  },
+  "71": {
+    "inputs": {
+      "clip_name": "qwen_3_4b.safetensors",
+      "type": "flux2",
+      "device": "default"
+    },
+    "class_type": "CLIPLoader",
+    "_meta": {
+      "title": "Load CLIP"
+    }
+  },
+  "72": {
+    "inputs": {
+      "vae_name": "flux2-vae.safetensors"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": "Load VAE"
+    }
+  },
+  "74": {
+    "inputs": {
+      "text": "",
+      "clip": [
+        "71",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "Positive prompt"
+    }
+  },
+  "82": {
+    "inputs": {
+      "conditioning": [
+        "74",
+        0
+      ]
+    },
+    "class_type": "ConditioningZeroOut",
+    "_meta": {
+      "title": "Negative (zeroed)"
+    }
+  },
+  "20": {
+    "inputs": {
+      "image": "flux2_ref1.png"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Reference 1"
+    }
+  },
+  "21": {
+    "inputs": {
+      "image": "flux2_ref2.png"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Reference 2"
+    }
+  },
+  "22": {
+    "inputs": {
+      "image": "flux2_ref3.png"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Reference 3"
+    }
+  },
+  "23": {
+    "inputs": {
+      "image": "flux2_ref4.png"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Reference 4"
+    }
+  },
+  "30": {
+    "inputs": {
+      "upscale_method": "nearest-exact",
+      "megapixels": 1.0,
+      "resolution_steps": 1,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "ImageScaleToTotalPixels",
+    "_meta": {
+      "title": "Scale ref 1"
+    }
+  },
+  "31": {
+    "inputs": {
+      "upscale_method": "nearest-exact",
+      "megapixels": 1.0,
+      "resolution_steps": 1,
+      "image": [
+        "21",
+        0
+      ]
+    },
+    "class_type": "ImageScaleToTotalPixels",
+    "_meta": {
+      "title": "Scale ref 2"
+    }
+  },
+  "32": {
+    "inputs": {
+      "upscale_method": "nearest-exact",
+      "megapixels": 1.0,
+      "resolution_steps": 1,
+      "image": [
+        "22",
+        0
+      ]
+    },
+    "class_type": "ImageScaleToTotalPixels",
+    "_meta": {
+      "title": "Scale ref 3"
+    }
+  },
+  "33": {
+    "inputs": {
+      "upscale_method": "nearest-exact",
+      "megapixels": 1.0,
+      "resolution_steps": 1,
+      "image": [
+        "23",
+        0
+      ]
+    },
+    "class_type": "ImageScaleToTotalPixels",
+    "_meta": {
+      "title": "Scale ref 4"
+    }
+  },
+  "40": {
+    "inputs": {
+      "pixels": [
+        "30",
+        0
+      ],
+      "vae": [
+        "72",
+        0
+      ]
+    },
+    "class_type": "VAEEncode",
+    "_meta": {
+      "title": "Encode ref 1"
+    }
+  },
+  "41": {
+    "inputs": {
+      "pixels": [
+        "31",
+        0
+      ],
+      "vae": [
+        "72",
+        0
+      ]
+    },
+    "class_type": "VAEEncode",
+    "_meta": {
+      "title": "Encode ref 2"
+    }
+  },
+  "42": {
+    "inputs": {
+      "pixels": [
+        "32",
+        0
+      ],
+      "vae": [
+        "72",
+        0
+      ]
+    },
+    "class_type": "VAEEncode",
+    "_meta": {
+      "title": "Encode ref 3"
+    }
+  },
+  "43": {
+    "inputs": {
+      "pixels": [
+        "33",
+        0
+      ],
+      "vae": [
+        "72",
+        0
+      ]
+    },
+    "class_type": "VAEEncode",
+    "_meta": {
+      "title": "Encode ref 4"
+    }
+  },
+  "50": {
+    "inputs": {
+      "conditioning": [
+        "74",
+        0
+      ],
+      "latent": [
+        "40",
+        0
+      ]
+    },
+    "class_type": "ReferenceLatent",
+    "_meta": {
+      "title": "Ref latent 1 (positive)"
+    }
+  },
+  "51": {
+    "inputs": {
+      "conditioning": [
+        "50",
+        0
+      ],
+      "latent": [
+        "41",
+        0
+      ]
+    },
+    "class_type": "ReferenceLatent",
+    "_meta": {
+      "title": "Ref latent 2 (positive)"
+    }
+  },
+  "52": {
+    "inputs": {
+      "conditioning": [
+        "51",
+        0
+      ],
+      "latent": [
+        "42",
+        0
+      ]
+    },
+    "class_type": "ReferenceLatent",
+    "_meta": {
+      "title": "Ref latent 3 (positive)"
+    }
+  },
+  "53": {
+    "inputs": {
+      "conditioning": [
+        "52",
+        0
+      ],
+      "latent": [
+        "43",
+        0
+      ]
+    },
+    "class_type": "ReferenceLatent",
+    "_meta": {
+      "title": "Ref latent 4 (positive)"
+    }
+  },
+  "60": {
+    "inputs": {
+      "conditioning": [
+        "82",
+        0
+      ],
+      "latent": [
+        "40",
+        0
+      ]
+    },
+    "class_type": "ReferenceLatent",
+    "_meta": {
+      "title": "Ref latent 1 (negative)"
+    }
+  },
+  "61": {
+    "inputs": {
+      "conditioning": [
+        "60",
+        0
+      ],
+      "latent": [
+        "41",
+        0
+      ]
+    },
+    "class_type": "ReferenceLatent",
+    "_meta": {
+      "title": "Ref latent 2 (negative)"
+    }
+  },
+  "62": {
+    "inputs": {
+      "conditioning": [
+        "61",
+        0
+      ],
+      "latent": [
+        "42",
+        0
+      ]
+    },
+    "class_type": "ReferenceLatent",
+    "_meta": {
+      "title": "Ref latent 3 (negative)"
+    }
+  },
+  "63": {
+    "inputs": {
+      "conditioning": [
+        "62",
+        0
+      ],
+      "latent": [
+        "43",
+        0
+      ]
+    },
+    "class_type": "ReferenceLatent",
+    "_meta": {
+      "title": "Ref latent 4 (negative)"
+    }
+  },
+  "66": {
+    "inputs": {
+      "width": 1024,
+      "height": 1024,
+      "batch_size": 1
+    },
+    "class_type": "EmptyFlux2LatentImage",
+    "_meta": {
+      "title": "Empty Flux 2 Latent"
+    }
+  },
+  "67": {
+    "inputs": {
+      "steps": 4,
+      "width": 1024,
+      "height": 1024
+    },
+    "class_type": "Flux2Scheduler",
+    "_meta": {
+      "title": "Flux2Scheduler (distilled 4-step)"
+    }
+  },
+  "68": {
+    "inputs": {
+      "sampler_name": "euler"
+    },
+    "class_type": "KSamplerSelect",
+    "_meta": {
+      "title": "KSamplerSelect"
+    }
+  },
+  "73": {
+    "inputs": {
+      "noise_seed": 0
+    },
+    "class_type": "RandomNoise",
+    "_meta": {
+      "title": "RandomNoise"
+    }
+  },
+  "76": {
+    "inputs": {
+      "cfg": 1,
+      "model": [
+        "70",
+        0
+      ],
+      "positive": [
+        "53",
+        0
+      ],
+      "negative": [
+        "63",
+        0
+      ]
+    },
+    "class_type": "CFGGuider",
+    "_meta": {
+      "title": "CFGGuider"
+    }
+  },
+  "77": {
+    "inputs": {
+      "noise": [
+        "73",
+        0
+      ],
+      "guider": [
+        "76",
+        0
+      ],
+      "sampler": [
+        "68",
+        0
+      ],
+      "sigmas": [
+        "67",
+        0
+      ],
+      "latent_image": [
+        "66",
+        0
+      ]
+    },
+    "class_type": "SamplerCustomAdvanced",
+    "_meta": {
+      "title": "SamplerCustomAdvanced"
+    }
+  },
+  "78": {
+    "inputs": {
+      "samples": [
+        "77",
+        0
+      ],
+      "vae": [
+        "72",
+        0
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "90": {
+    "inputs": {
+      "filename_prefix": "vidpipe_flux2klein",
+      "images": [
+        "78",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "Save Image"
+    }
+  }
+}

--- a/backend/vidpipe/services/comfyui_templates/ltx-flf2v.json
+++ b/backend/vidpipe/services/comfyui_templates/ltx-flf2v.json
@@ -1,0 +1,398 @@
+{
+  "1": {
+    "inputs": {
+      "ckpt_name": "ltx-2.3-22b-distilled-fp8.safetensors"
+    },
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {
+      "title": "Load LTX-2.3 checkpoint"
+    }
+  },
+  "2": {
+    "inputs": {
+      "text_encoder": "gemma_3_12B_it_fp4_mixed.safetensors",
+      "ckpt_name": "ltx-2.3-22b-distilled-fp8.safetensors",
+      "device": "default"
+    },
+    "class_type": "LTXAVTextEncoderLoader",
+    "_meta": {
+      "title": "Load Gemma text encoder"
+    }
+  },
+  "3": {
+    "inputs": {
+      "ckpt_name": "ltx-2.3-22b-distilled-fp8.safetensors"
+    },
+    "class_type": "LTXVAudioVAELoader",
+    "_meta": {
+      "title": "Load audio VAE"
+    }
+  },
+  "4": {
+    "inputs": {
+      "text": "",
+      "clip": [
+        "2",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "Positive prompt"
+    }
+  },
+  "5": {
+    "inputs": {
+      "text": "",
+      "clip": [
+        "2",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "Negative prompt"
+    }
+  },
+  "6": {
+    "inputs": {
+      "frame_rate": 25,
+      "positive": [
+        "4",
+        0
+      ],
+      "negative": [
+        "5",
+        0
+      ]
+    },
+    "class_type": "LTXVConditioning",
+    "_meta": {
+      "title": "LTXV Conditioning"
+    }
+  },
+  "10": {
+    "inputs": {
+      "image": "ltx_start.png"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Start keyframe (pre-resized to output dims)"
+    }
+  },
+  "12": {
+    "inputs": {
+      "img_compression": 25,
+      "image": [
+        "10",
+        0
+      ]
+    },
+    "class_type": "LTXVPreprocess",
+    "_meta": {
+      "title": "Preprocess start frame"
+    }
+  },
+  "13": {
+    "inputs": {
+      "image": "ltx_end.png"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "End keyframe (pre-resized to output dims)"
+    }
+  },
+  "15": {
+    "inputs": {
+      "img_compression": 25,
+      "image": [
+        "13",
+        0
+      ]
+    },
+    "class_type": "LTXVPreprocess",
+    "_meta": {
+      "title": "Preprocess end frame"
+    }
+  },
+  "16": {
+    "inputs": {
+      "width": 1280,
+      "height": 720,
+      "length": 126,
+      "batch_size": 1
+    },
+    "class_type": "EmptyLTXVLatentVideo",
+    "_meta": {
+      "title": "Empty video latent"
+    }
+  },
+  "17": {
+    "inputs": {
+      "frame_idx": 0,
+      "strength": 0.7,
+      "positive": [
+        "6",
+        0
+      ],
+      "negative": [
+        "6",
+        1
+      ],
+      "vae": [
+        "1",
+        2
+      ],
+      "latent": [
+        "16",
+        0
+      ],
+      "image": [
+        "12",
+        0
+      ]
+    },
+    "class_type": "LTXVAddGuide",
+    "_meta": {
+      "title": "First frame guide"
+    }
+  },
+  "18": {
+    "inputs": {
+      "frame_idx": -1,
+      "strength": 0.7,
+      "positive": [
+        "17",
+        0
+      ],
+      "negative": [
+        "17",
+        1
+      ],
+      "vae": [
+        "1",
+        2
+      ],
+      "latent": [
+        "17",
+        2
+      ],
+      "image": [
+        "15",
+        0
+      ]
+    },
+    "class_type": "LTXVAddGuide",
+    "_meta": {
+      "title": "Last frame guide"
+    }
+  },
+  "19": {
+    "inputs": {
+      "frames_number": 126,
+      "frame_rate": 25,
+      "batch_size": 1,
+      "audio_vae": [
+        "3",
+        0
+      ]
+    },
+    "class_type": "LTXVEmptyLatentAudio",
+    "_meta": {
+      "title": "Empty audio latent"
+    }
+  },
+  "20": {
+    "inputs": {
+      "video_latent": [
+        "18",
+        2
+      ],
+      "audio_latent": [
+        "19",
+        0
+      ]
+    },
+    "class_type": "LTXVConcatAVLatent",
+    "_meta": {
+      "title": "Concat AV latent"
+    }
+  },
+  "21": {
+    "inputs": {
+      "noise_seed": 0
+    },
+    "class_type": "RandomNoise",
+    "_meta": {
+      "title": "RandomNoise"
+    }
+  },
+  "22": {
+    "inputs": {
+      "cfg": 1,
+      "model": [
+        "1",
+        0
+      ],
+      "positive": [
+        "18",
+        0
+      ],
+      "negative": [
+        "18",
+        1
+      ]
+    },
+    "class_type": "CFGGuider",
+    "_meta": {
+      "title": "CFGGuider"
+    }
+  },
+  "23": {
+    "inputs": {
+      "eta": 0,
+      "s_noise": 1
+    },
+    "class_type": "SamplerEulerAncestral",
+    "_meta": {
+      "title": "SamplerEulerAncestral"
+    }
+  },
+  "24": {
+    "inputs": {
+      "sigmas": "1., 0.99375, 0.9875, 0.98125, 0.975, 0.909375, 0.725, 0.421875, 0.0"
+    },
+    "class_type": "ManualSigmas",
+    "_meta": {
+      "title": "Distilled sigmas"
+    }
+  },
+  "25": {
+    "inputs": {
+      "noise": [
+        "21",
+        0
+      ],
+      "guider": [
+        "22",
+        0
+      ],
+      "sampler": [
+        "23",
+        0
+      ],
+      "sigmas": [
+        "24",
+        0
+      ],
+      "latent_image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "SamplerCustomAdvanced",
+    "_meta": {
+      "title": "SamplerCustomAdvanced"
+    }
+  },
+  "26": {
+    "inputs": {
+      "av_latent": [
+        "25",
+        1
+      ]
+    },
+    "class_type": "LTXVSeparateAVLatent",
+    "_meta": {
+      "title": "Separate AV latent"
+    }
+  },
+  "27": {
+    "inputs": {
+      "positive": [
+        "18",
+        0
+      ],
+      "negative": [
+        "18",
+        1
+      ],
+      "latent": [
+        "26",
+        0
+      ]
+    },
+    "class_type": "LTXVCropGuides",
+    "_meta": {
+      "title": "Crop guides"
+    }
+  },
+  "28": {
+    "inputs": {
+      "tile_size": 768,
+      "overlap": 64,
+      "temporal_size": 4096,
+      "temporal_overlap": 64,
+      "samples": [
+        "27",
+        2
+      ],
+      "vae": [
+        "1",
+        2
+      ]
+    },
+    "class_type": "VAEDecodeTiled",
+    "_meta": {
+      "title": "VAE Decode (tiled)"
+    }
+  },
+  "29": {
+    "inputs": {
+      "samples": [
+        "26",
+        1
+      ],
+      "audio_vae": [
+        "3",
+        0
+      ]
+    },
+    "class_type": "LTXVAudioVAEDecode",
+    "_meta": {
+      "title": "Decode audio"
+    }
+  },
+  "30": {
+    "inputs": {
+      "fps": 25,
+      "images": [
+        "28",
+        0
+      ],
+      "audio": [
+        "29",
+        0
+      ]
+    },
+    "class_type": "CreateVideo",
+    "_meta": {
+      "title": "Create Video"
+    }
+  },
+  "31": {
+    "inputs": {
+      "filename_prefix": "video/vidpipe_ltx_flf2v",
+      "format": "auto",
+      "codec": "auto",
+      "video": [
+        "30",
+        0
+      ]
+    },
+    "class_type": "SaveVideo",
+    "_meta": {
+      "title": "Save Video"
+    }
+  }
+}

--- a/backend/vidpipe/services/comfyui_templates/qwen-edit-2509.json
+++ b/backend/vidpipe/services/comfyui_templates/qwen-edit-2509.json
@@ -1,0 +1,287 @@
+{
+  "10": {
+    "inputs": {
+      "image": "qwen2509_image1.png"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Image 1 (start frame or primary reference)"
+    }
+  },
+  "11": {
+    "inputs": {
+      "image": "qwen2509_image2.png"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Image 2 (optional reference)"
+    }
+  },
+  "12": {
+    "inputs": {
+      "image": "qwen2509_image3.png"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Image 3 (optional reference)"
+    }
+  },
+  "37": {
+    "inputs": {
+      "unet_name": "qwen_image_edit_2509_fp8_e4m3fn.safetensors",
+      "weight_dtype": "default"
+    },
+    "class_type": "UNETLoader",
+    "_meta": {
+      "title": "Load Diffusion Model"
+    }
+  },
+  "38": {
+    "inputs": {
+      "clip_name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+      "type": "qwen_image",
+      "device": "default"
+    },
+    "class_type": "CLIPLoader",
+    "_meta": {
+      "title": "Load CLIP"
+    }
+  },
+  "39": {
+    "inputs": {
+      "vae_name": "qwen_image_vae.safetensors"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": "Load VAE"
+    }
+  },
+  "89": {
+    "inputs": {
+      "lora_name": "Qwen-Image-Edit-2509-Lightning-4steps-V1.0-bf16.safetensors",
+      "strength_model": 1.0,
+      "model": [
+        "37",
+        0
+      ]
+    },
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {
+      "title": "Lightning 4-step LoRA"
+    }
+  },
+  "66": {
+    "inputs": {
+      "shift": 3,
+      "model": [
+        "89",
+        0
+      ]
+    },
+    "class_type": "ModelSamplingAuraFlow",
+    "_meta": {
+      "title": "ModelSamplingAuraFlow"
+    }
+  },
+  "75": {
+    "inputs": {
+      "strength": 1,
+      "model": [
+        "66",
+        0
+      ]
+    },
+    "class_type": "CFGNorm",
+    "_meta": {
+      "title": "CFGNorm"
+    }
+  },
+  "117": {
+    "inputs": {
+      "image": [
+        "10",
+        0
+      ]
+    },
+    "class_type": "FluxKontextImageScale",
+    "_meta": {
+      "title": "Scale image 1 to optimal edit resolution"
+    }
+  },
+  "88": {
+    "inputs": {
+      "pixels": [
+        "117",
+        0
+      ],
+      "vae": [
+        "39",
+        0
+      ]
+    },
+    "class_type": "VAEEncode",
+    "_meta": {
+      "title": "Encode image 1 latent"
+    }
+  },
+  "107": {
+    "inputs": {
+      "width": 1328,
+      "height": 1328,
+      "batch_size": 1
+    },
+    "class_type": "EmptySD3LatentImage",
+    "_meta": {
+      "title": "Empty latent (start-frame mode output size)"
+    }
+  },
+  "110": {
+    "inputs": {
+      "prompt": "",
+      "clip": [
+        "38",
+        0
+      ],
+      "vae": [
+        "39",
+        0
+      ],
+      "image1": [
+        "117",
+        0
+      ],
+      "image2": [
+        "11",
+        0
+      ],
+      "image3": [
+        "12",
+        0
+      ]
+    },
+    "class_type": "TextEncodeQwenImageEditPlus",
+    "_meta": {
+      "title": "Positive prompt"
+    }
+  },
+  "111": {
+    "inputs": {
+      "prompt": "",
+      "clip": [
+        "38",
+        0
+      ],
+      "vae": [
+        "39",
+        0
+      ],
+      "image1": [
+        "117",
+        0
+      ],
+      "image2": [
+        "11",
+        0
+      ],
+      "image3": [
+        "12",
+        0
+      ]
+    },
+    "class_type": "TextEncodeQwenImageEditPlus",
+    "_meta": {
+      "title": "Negative prompt"
+    }
+  },
+  "467": {
+    "inputs": {
+      "conditioning": [
+        "110",
+        0
+      ],
+      "latent": [
+        "88",
+        0
+      ]
+    },
+    "class_type": "ReferenceLatent",
+    "_meta": {
+      "title": "Reference latent (positive)"
+    }
+  },
+  "468": {
+    "inputs": {
+      "conditioning": [
+        "111",
+        0
+      ],
+      "latent": [
+        "88",
+        0
+      ]
+    },
+    "class_type": "ReferenceLatent",
+    "_meta": {
+      "title": "Reference latent (negative)"
+    }
+  },
+  "3": {
+    "inputs": {
+      "seed": 0,
+      "steps": 4,
+      "cfg": 1.0,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "denoise": 1.0,
+      "model": [
+        "75",
+        0
+      ],
+      "positive": [
+        "467",
+        0
+      ],
+      "negative": [
+        "468",
+        0
+      ],
+      "latent_image": [
+        "88",
+        0
+      ]
+    },
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "KSampler (lightning 4-step)"
+    }
+  },
+  "8": {
+    "inputs": {
+      "samples": [
+        "3",
+        0
+      ],
+      "vae": [
+        "39",
+        0
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "60": {
+    "inputs": {
+      "filename_prefix": "vidpipe_qwen2509",
+      "images": [
+        "8",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "Save Image"
+    }
+  }
+}

--- a/backend/vidpipe/services/comfyui_templates/seedance-flf2v.json
+++ b/backend/vidpipe/services/comfyui_templates/seedance-flf2v.json
@@ -1,0 +1,61 @@
+{
+  "1": {
+    "inputs": {
+      "image": "seedance_first.png"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "First frame"
+    }
+  },
+  "2": {
+    "inputs": {
+      "image": "seedance_last.png"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Last frame (optional)"
+    }
+  },
+  "3": {
+    "inputs": {
+      "model": "Seedance 2.0",
+      "model.prompt": "",
+      "model.resolution": "720p",
+      "model.ratio": "16:9",
+      "model.duration": 5,
+      "model.generate_audio": true,
+      "first_frame": [
+        "1",
+        0
+      ],
+      "last_frame": [
+        "2",
+        0
+      ],
+      "first_frame_asset_id": "",
+      "last_frame_asset_id": "",
+      "seed": 0,
+      "watermark": false
+    },
+    "class_type": "ByteDance2FirstLastFrameNode",
+    "_meta": {
+      "title": "Seedance 2.0 First-Last-Frame to Video"
+    }
+  },
+  "4": {
+    "inputs": {
+      "filename_prefix": "video/vidpipe_seedance2",
+      "format": "auto",
+      "codec": "auto",
+      "video": [
+        "3",
+        0
+      ]
+    },
+    "class_type": "SaveVideo",
+    "_meta": {
+      "title": "Save Video"
+    }
+  }
+}

--- a/backend/vidpipe/services/comfyui_templates/wan-flf2v.json
+++ b/backend/vidpipe/services/comfyui_templates/wan-flf2v.json
@@ -188,11 +188,11 @@
   "94": {
     "class_type": "CreateVideo",
     "inputs": {
+      "fps": 16,
       "images": [
         "87",
         0
-      ],
-      "frame_rate": 16
+      ]
     }
   },
   "108": {

--- a/backend/vidpipe/services/comfyui_templates/wan-flf2v.json
+++ b/backend/vidpipe/services/comfyui_templates/wan-flf2v.json
@@ -1,0 +1,349 @@
+{
+  "84": {
+    "class_type": "CLIPLoader",
+    "inputs": {
+      "clip_name": "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+      "type": "wan",
+      "device": "default"
+    }
+  },
+  "90": {
+    "class_type": "VAELoader",
+    "inputs": {
+      "vae_name": "wan_2.1_vae.safetensors"
+    }
+  },
+  "95": {
+    "class_type": "UNETLoader",
+    "inputs": {
+      "unet_name": "wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors",
+      "weight_dtype": "default"
+    }
+  },
+  "96": {
+    "class_type": "UNETLoader",
+    "inputs": {
+      "unet_name": "wan2.2_i2v_low_noise_14B_fp8_scaled.safetensors",
+      "weight_dtype": "default"
+    }
+  },
+  "104": {
+    "class_type": "ModelSamplingSD3",
+    "inputs": {
+      "model": [
+        "95",
+        0
+      ],
+      "shift": 8.0
+    }
+  },
+  "103": {
+    "class_type": "ModelSamplingSD3",
+    "inputs": {
+      "model": [
+        "96",
+        0
+      ],
+      "shift": 8.0
+    }
+  },
+  "93": {
+    "class_type": "CLIPTextEncode",
+    "inputs": {
+      "clip": [
+        "84",
+        0
+      ],
+      "text": "A person walks forward confidently, the camera slowly following their movement. Natural lighting, cinematic motion."
+    }
+  },
+  "89": {
+    "class_type": "CLIPTextEncode",
+    "inputs": {
+      "clip": [
+        "84",
+        0
+      ],
+      "text": "blurry, low quality, distorted, watermark, text overlay, static, jerky motion, artifacts, overexposed, underexposed, noise, grain, flickering, morphing face, extra limbs, deformed hands, duplicate characters, cartoon, anime"
+    }
+  },
+  "97": {
+    "class_type": "LoadImage",
+    "inputs": {
+      "image": "start_keyframe.png",
+      "upload": "image"
+    }
+  },
+  "200": {
+    "class_type": "LoadImage",
+    "inputs": {
+      "image": "end_keyframe.png",
+      "upload": "image"
+    }
+  },
+  "98": {
+    "class_type": "WanFirstLastFrameToVideo",
+    "inputs": {
+      "positive": [
+        "93",
+        0
+      ],
+      "negative": [
+        "89",
+        0
+      ],
+      "vae": [
+        "90",
+        0
+      ],
+      "start_image": [
+        "97",
+        0
+      ],
+      "end_image": [
+        "200",
+        0
+      ],
+      "width": 832,
+      "height": 480,
+      "length": 81,
+      "batch_size": 1
+    }
+  },
+  "86": {
+    "class_type": "KSamplerAdvanced",
+    "inputs": {
+      "model": [
+        "104",
+        0
+      ],
+      "positive": [
+        "98",
+        0
+      ],
+      "negative": [
+        "98",
+        1
+      ],
+      "latent_image": [
+        "98",
+        2
+      ],
+      "add_noise": "enable",
+      "noise_seed": 0,
+      "control_after_generate": "randomize",
+      "steps": 40,
+      "cfg": 5.0,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "start_at_step": 0,
+      "end_at_step": 20,
+      "return_with_leftover_noise": "enable"
+    }
+  },
+  "85": {
+    "class_type": "KSamplerAdvanced",
+    "inputs": {
+      "model": [
+        "103",
+        0
+      ],
+      "positive": [
+        "98",
+        0
+      ],
+      "negative": [
+        "98",
+        1
+      ],
+      "latent_image": [
+        "86",
+        0
+      ],
+      "add_noise": "disable",
+      "noise_seed": 0,
+      "control_after_generate": "fixed",
+      "steps": 40,
+      "cfg": 5.0,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "start_at_step": 20,
+      "end_at_step": 40,
+      "return_with_leftover_noise": "disable"
+    }
+  },
+  "87": {
+    "class_type": "VAEDecode",
+    "inputs": {
+      "samples": [
+        "85",
+        0
+      ],
+      "vae": [
+        "90",
+        0
+      ]
+    }
+  },
+  "94": {
+    "class_type": "CreateVideo",
+    "inputs": {
+      "images": [
+        "87",
+        0
+      ],
+      "frame_rate": 16
+    }
+  },
+  "108": {
+    "class_type": "SaveVideo",
+    "inputs": {
+      "video": [
+        "94",
+        0
+      ],
+      "filename_prefix": "video/flf2v_prod",
+      "format": "auto",
+      "codec": "auto"
+    }
+  },
+  "210": {
+    "class_type": "ImageFromBatch",
+    "inputs": {
+      "image": [
+        "87",
+        0
+      ],
+      "batch_index": 0,
+      "length": 1
+    }
+  },
+  "220": {
+    "class_type": "SaveImage",
+    "inputs": {
+      "images": [
+        "210",
+        0
+      ],
+      "filename_prefix": "qc_frames/frame_000"
+    }
+  },
+  "211": {
+    "class_type": "ImageFromBatch",
+    "inputs": {
+      "image": [
+        "87",
+        0
+      ],
+      "batch_index": 20,
+      "length": 1
+    }
+  },
+  "221": {
+    "class_type": "SaveImage",
+    "inputs": {
+      "images": [
+        "211",
+        0
+      ],
+      "filename_prefix": "qc_frames/frame_020"
+    }
+  },
+  "212": {
+    "class_type": "ImageFromBatch",
+    "inputs": {
+      "image": [
+        "87",
+        0
+      ],
+      "batch_index": 40,
+      "length": 1
+    }
+  },
+  "222": {
+    "class_type": "SaveImage",
+    "inputs": {
+      "images": [
+        "212",
+        0
+      ],
+      "filename_prefix": "qc_frames/frame_040"
+    }
+  },
+  "213": {
+    "class_type": "ImageFromBatch",
+    "inputs": {
+      "image": [
+        "87",
+        0
+      ],
+      "batch_index": 60,
+      "length": 1
+    }
+  },
+  "223": {
+    "class_type": "SaveImage",
+    "inputs": {
+      "images": [
+        "213",
+        0
+      ],
+      "filename_prefix": "qc_frames/frame_060"
+    }
+  },
+  "214": {
+    "class_type": "ImageFromBatch",
+    "inputs": {
+      "image": [
+        "87",
+        0
+      ],
+      "batch_index": 80,
+      "length": 1
+    }
+  },
+  "224": {
+    "class_type": "SaveImage",
+    "inputs": {
+      "images": [
+        "214",
+        0
+      ],
+      "filename_prefix": "qc_frames/frame_080"
+    }
+  },
+  "201": {
+    "class_type": "LoadImage",
+    "inputs": {
+      "image": "char_ref_01.png",
+      "upload": "image"
+    }
+  },
+  "225": {
+    "class_type": "SaveImage",
+    "inputs": {
+      "images": [
+        "201",
+        0
+      ],
+      "filename_prefix": "qc_ref/char_ref_01"
+    }
+  },
+  "202": {
+    "class_type": "LoadImage",
+    "inputs": {
+      "image": "char_ref_02.png",
+      "upload": "image"
+    }
+  },
+  "226": {
+    "class_type": "SaveImage",
+    "inputs": {
+      "images": [
+        "202",
+        0
+      ],
+      "filename_prefix": "qc_ref/char_ref_02"
+    }
+  }
+}

--- a/backend/vidpipe/services/cv_analysis_service.py
+++ b/backend/vidpipe/services/cv_analysis_service.py
@@ -114,6 +114,7 @@ class CVAnalysisService:
         clip_path: Optional[str],
         shot_manifest_json: Optional[dict],
         existing_assets: list[Asset],
+        vision_adapter: Optional[LLMAdapter] = None,
     ) -> CVAnalysisResult:
         """Orchestrate full CV analysis on a generated shot.
 
@@ -315,7 +316,7 @@ class CVAnalysisService:
                 detections=frame_detections,
                 shot_manifest_json=shot_manifest_json,
                 face_matches=face_matches,
-                vision_adapter=self._vision_adapter,
+                vision_adapter=vision_adapter or self._vision_adapter,
             )
             result.semantic_analysis = semantic
 

--- a/backend/vidpipe/services/entity_extraction.py
+++ b/backend/vidpipe/services/entity_extraction.py
@@ -26,6 +26,7 @@ Manifest = ProductionBible
 from vidpipe.services.clip_embedding_service import CLIPEmbeddingService
 from vidpipe.services.cv_analysis_service import CVAnalysisResult, FaceMatchResult
 from vidpipe.services.face_matching import FaceMatchingService
+from vidpipe.services.llm import LLMAdapter
 from vidpipe.services.reverse_prompt_service import ReversePromptService
 
 logger = logging.getLogger(__name__)
@@ -218,6 +219,7 @@ async def extract_and_register_new_entities(
     shot_index: int,
     new_entities: list[NewEntityDetection],
     source: str = "CLIP_EXTRACT",
+    vision_adapter: Optional[LLMAdapter] = None,
 ) -> list[Asset]:
     """Reverse-prompt, quality-gate, and register new entities as assets.
 
@@ -246,7 +248,7 @@ async def extract_and_register_new_entities(
     from vidpipe.services.manifest_service import TAG_PREFIX_MAP
 
     semaphore = asyncio.Semaphore(3)
-    reverse_service = ReversePromptService()
+    reverse_service = ReversePromptService(vision_adapter=vision_adapter)
     face_service = FaceMatchingService()
     clip_service = CLIPEmbeddingService()
 

--- a/backend/vidpipe/services/face_restore_service.py
+++ b/backend/vidpipe/services/face_restore_service.py
@@ -93,6 +93,20 @@ class FaceRestoreService:
     def available(self) -> bool:
         return self._load()
 
+    def release(self) -> None:
+        """Free torch's cached (reserved-but-unused) GPU memory after a heavy job.
+
+        Releases the caching-allocator blocks the 4x upscale balloons to (5K
+        tiles); the model weights stay resident for reuse. Safe no-op on CPU.
+        """
+        try:
+            import torch
+
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+        except Exception:  # noqa: BLE001
+            pass
+
     def has_restore(self) -> bool:
         return self._load() and self._cf is not None
 

--- a/backend/vidpipe/services/face_restore_service.py
+++ b/backend/vidpipe/services/face_restore_service.py
@@ -1,0 +1,213 @@
+"""GPU face restoration (CodeFormer) + super-resolution (RealESRGAN) via spandrel.
+
+The inswapper swap is only 128px, so on a high-res keyframe the face comes back
+soft. This service re-renders the swapped face at 512px with realistic detail
+(CodeFormer) and pastes it back aligned, and can 4x-upscale a full frame
+(RealESRGAN, tiled to fit 12GB VRAM).
+
+Both are PyTorch models run via ``spandrel`` on the GPU (``torch.cuda``) — this
+sidesteps the onnxruntime CPU/GPU package conflict entirely; only the cheap
+128px swap stays on onnxruntime/CPU. Degrades gracefully (``available()`` False)
+when torch/spandrel or the weights are missing, so the pipeline still runs.
+
+Validated 2026-06-13 on an RTX 4070 Ti: CodeFormer restore ~0.75s/face,
+RealESRGAN 4x ~3.8s/frame (tiled). CodeFormer ``weight`` is the fidelity knob —
+0.9 keeps Brandon's identity (~0.81 vs a held-out real ref) while sharpening;
+lower weights drift identity.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# FFHQ-512 five-point template — the standard GFPGAN/CodeFormer face alignment.
+_FFHQ_512 = np.array(
+    [[192.98138, 239.94708], [318.90277, 240.19360], [256.63416, 314.01935],
+     [201.26117, 371.41043], [313.08905, 371.15118]],
+    dtype=np.float32,
+)
+
+
+class FaceRestoreService:
+    """Lazy-loaded CodeFormer + RealESRGAN (GPU). Singleton via accessor below."""
+
+    def __init__(self) -> None:
+        self._tried = False
+        self._cf = None       # CodeFormer descriptor
+        self._esr = None      # RealESRGAN descriptor
+        self._app = None      # buffalo_l detector (for align)
+        self._dev = "cpu"
+
+    def _load(self) -> bool:
+        if self._tried:
+            return self._cf is not None or self._esr is not None
+        self._tried = True
+        try:
+            import torch
+            from spandrel import ModelLoader, MAIN_REGISTRY
+
+            try:
+                from spandrel_extra_arches import EXTRA_REGISTRY
+
+                MAIN_REGISTRY.add(*EXTRA_REGISTRY)
+            except Exception as e:  # noqa: BLE001 - CodeFormer arch lives in extra_arches
+                logger.warning("spandrel_extra_arches unavailable (CodeFormer may not load): %s", e)
+
+            from vidpipe.config import settings
+
+            self._dev = "cuda" if torch.cuda.is_available() else "cpu"
+            mdir = settings.face_swap.restore_model_dir
+            loader = ModelLoader(device=self._dev)
+
+            cf_path = os.path.join(mdir, "codeformer.pth")
+            esr_path = os.path.join(mdir, "RealESRGAN_x4plus.pth")
+            if os.path.exists(cf_path):
+                self._cf = loader.load_from_file(cf_path).eval()
+            else:
+                logger.warning("Face-restore: CodeFormer weight missing at %s", cf_path)
+            if os.path.exists(esr_path):
+                self._esr = loader.load_from_file(esr_path).eval()
+            else:
+                logger.warning("Face-restore: RealESRGAN weight missing at %s", esr_path)
+
+            if self._cf is not None or self._esr is not None:
+                from insightface.app import FaceAnalysis
+
+                self._app = FaceAnalysis(name="buffalo_l", providers=["CPUExecutionProvider"])
+                self._app.prepare(ctx_id=-1, det_size=(640, 640))
+                logger.info(
+                    "FaceRestoreService ready (device=%s, codeformer=%s, realesrgan=%s).",
+                    self._dev, self._cf is not None, self._esr is not None,
+                )
+        except Exception as e:  # noqa: BLE001 - any failure → restore unavailable
+            logger.warning("Face-restore unavailable: %s", e)
+            self._cf = self._esr = None
+        return self._cf is not None or self._esr is not None
+
+    def available(self) -> bool:
+        return self._load()
+
+    def has_restore(self) -> bool:
+        return self._load() and self._cf is not None
+
+    def has_upscale(self) -> bool:
+        return self._load() and self._esr is not None
+
+    # --- image helpers --------------------------------------------------
+    @staticmethod
+    def _decode(data: bytes):
+        import cv2
+
+        return cv2.imdecode(np.frombuffer(data, np.uint8), cv2.IMREAD_COLOR)
+
+    @staticmethod
+    def _encode(bgr) -> bytes:
+        import cv2
+
+        ok, buf = cv2.imencode(".png", bgr)
+        return buf.tobytes() if ok else b""
+
+    def _to_dev(self, bgr):
+        import cv2
+        import torch
+
+        rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB).astype(np.float32) / 255.0
+        return torch.from_numpy(rgb).permute(2, 0, 1).unsqueeze(0).to(self._dev)
+
+    def _to_bgr(self, t):
+        import cv2
+
+        a = t.squeeze(0).permute(1, 2, 0).clamp(0, 1).detach().cpu().numpy() * 255.0
+        return cv2.cvtColor(a.astype(np.uint8), cv2.COLOR_RGB2BGR)
+
+    # --- public ops -----------------------------------------------------
+    def restore_primary_face(self, png: bytes) -> Optional[bytes]:
+        """CodeFormer-restore the largest face and paste it back. None if unavailable/no face."""
+        if not self.has_restore():
+            return None
+        try:
+            import cv2
+            import torch
+
+            from vidpipe.config import settings
+
+            weight = float(settings.face_swap.restore_weight)
+            img = self._decode(png)
+            if img is None:
+                return None
+            faces = self._app.get(img)
+            if not faces:
+                return None
+            f = max(faces, key=lambda x: (x.bbox[2] - x.bbox[0]) * (x.bbox[3] - x.bbox[1]))
+            M, _ = cv2.estimateAffinePartial2D(
+                f.kps.astype(np.float32), _FFHQ_512, method=cv2.LMEDS
+            )
+            if M is None:
+                return None
+            h, w = img.shape[:2]
+            aligned = cv2.warpAffine(img, M, (512, 512), flags=cv2.INTER_LINEAR)
+            with torch.no_grad():
+                out = self._cf.model(self._to_dev(aligned), weight=weight)
+                if isinstance(out, (tuple, list)):
+                    out = out[0]
+            restored = self._to_bgr(out)
+
+            m_inv = cv2.invertAffineTransform(M)
+            back = cv2.warpAffine(restored, m_inv, (w, h))
+            # Blend with a soft FACE-SHAPED (elliptical) mask built in the aligned
+            # 512 space and feathered heavily, so the restored region fades as an
+            # oval that dies out well inside the crop — no square crop boundary /
+            # box-outline seam where restored meets original.
+            mask512 = np.zeros((512, 512), np.float32)
+            cv2.ellipse(mask512, (256, 286), (158, 198), 0, 0, 360, 1.0, -1)
+            mask512 = cv2.GaussianBlur(mask512, (0, 0), 26)
+            mask = np.clip(cv2.warpAffine(mask512, m_inv, (w, h)), 0.0, 1.0)[..., None]
+            full = (img * (1.0 - mask) + back * mask).astype(np.uint8)
+            return self._encode(full)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Face restore failed: %s", e)
+            return None
+
+    def upscale(self, png: bytes, scale: int = 4, tile: int = 512, overlap: int = 32) -> Optional[bytes]:
+        """RealESRGAN super-resolution, tiled to stay within VRAM. None if unavailable."""
+        if not self.has_upscale():
+            return None
+        try:
+            import torch
+
+            img = self._decode(png)
+            if img is None:
+                return None
+            s = int(getattr(self._esr, "scale", 4) or 4)
+            h, w = img.shape[:2]
+            out = np.zeros((h * s, w * s, 3), np.uint8)
+            for y in range(0, h, tile):
+                for x in range(0, w, tile):
+                    y2, x2 = min(y + tile, h), min(x + tile, w)
+                    ys, xs = max(0, y - overlap), max(0, x - overlap)
+                    ye, xe = min(h, y2 + overlap), min(w, x2 + overlap)
+                    with torch.no_grad():
+                        up = self._to_bgr(self._esr(self._to_dev(img[ys:ye, xs:xe])))
+                    ty, tx = (y - ys) * s, (x - xs) * s
+                    out[y * s:y2 * s, x * s:x2 * s] = up[ty:ty + (y2 - y) * s, tx:tx + (x2 - x) * s]
+            return self._encode(out)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Upscale failed: %s", e)
+            return None
+
+
+_SERVICE: Optional[FaceRestoreService] = None
+
+
+def get_face_restore_service() -> FaceRestoreService:
+    """Module-singleton accessor for the face-restore/upscale service."""
+    global _SERVICE
+    if _SERVICE is None:
+        _SERVICE = FaceRestoreService()
+    return _SERVICE

--- a/backend/vidpipe/services/face_swap_service.py
+++ b/backend/vidpipe/services/face_swap_service.py
@@ -1,0 +1,191 @@
+"""Post-generation face-swap service (InsightFace inswapper).
+
+Pastes a character's *real* reference face onto a generated keyframe so identity
+is exact regardless of which image model produced the keyframe. The swap uses
+the ``inswapper_128.onnx`` model plus the ``buffalo_l`` detector/recogniser that
+the rest of the pipeline already relies on (see ``qa/vision.py`` and
+``services/face_matching.py``).
+
+Runs CPU-only to match the GPU-disabled backend container (a 128px swap is fast
+on CPU). The ``inswapper_128.onnx`` weight is expected under
+``~/.insightface/models/`` — in Docker this is the volume-mounted
+``./models/insightface`` dir. When the weight is missing the service degrades
+gracefully (``available()`` returns False) so the pipeline proceeds with
+un-swapped keyframes rather than failing.
+
+Acquisition note: ``inswapper_128.onnx`` is gated/licensed — source it
+deliberately and confirm usage terms for the project's context.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+INSWAPPER_FILENAME = "inswapper_128.onnx"
+
+
+def _inswapper_path() -> str:
+    """Resolve the inswapper weight path (volume-mounted insightface model dir)."""
+    return os.path.join(
+        os.path.expanduser("~"), ".insightface", "models", INSWAPPER_FILENAME
+    )
+
+
+class FaceSwapService:
+    """Lazy-loaded InsightFace face swapper (CPU). Singleton via accessor below."""
+
+    def __init__(self) -> None:
+        self._app = None  # buffalo_l FaceAnalysis (detect + recognise)
+        self._swapper = None  # inswapper_128 INSwapper
+        self._tried = False
+        self._ok = False
+
+    def _load(self) -> bool:
+        """Lazy-init detector + swapper. Returns True if both are ready."""
+        if self._tried:
+            return self._ok
+        self._tried = True
+        try:
+            model_path = _inswapper_path()
+            if not os.path.exists(model_path):
+                logger.warning(
+                    "Face-swap unavailable: %s not found (mount ./models/insightface "
+                    "to /root/.insightface/models).",
+                    model_path,
+                )
+                self._ok = False
+                return False
+
+            import insightface  # type: ignore
+            from insightface.app import FaceAnalysis  # type: ignore
+
+            app = FaceAnalysis(name="buffalo_l", providers=["CPUExecutionProvider"])
+            app.prepare(ctx_id=-1, det_size=(640, 640))
+            self._app = app
+            self._swapper = insightface.model_zoo.get_model(
+                model_path, providers=["CPUExecutionProvider"]
+            )
+            self._ok = True
+            logger.info("FaceSwapService ready (inswapper_128, buffalo_l, CPU).")
+        except Exception as e:  # noqa: BLE001 - any failure → swap unavailable
+            logger.warning("Face-swap unavailable: %s", e)
+            self._ok = False
+        return self._ok
+
+    def available(self) -> bool:
+        """True when both models loaded (lazy-loads on first call)."""
+        return self._load()
+
+    @staticmethod
+    def _decode(data: bytes):
+        """PNG/JPEG bytes → BGR ndarray (or None if undecodable)."""
+        import cv2  # type: ignore
+        import numpy as np  # type: ignore
+
+        arr = np.frombuffer(data, dtype=np.uint8)
+        return cv2.imdecode(arr, cv2.IMREAD_COLOR)
+
+    def pick_clearest(self, candidate_pngs: list[bytes]) -> Optional[bytes]:
+        """Return the candidate whose best face has the highest detection score.
+
+        Reuses the same det_score ranking as reference prequalification so the
+        clearest real reference is chosen as the swap source. Returns None when
+        no candidate has a detectable face.
+        """
+        if not self._load():
+            return None
+        best_bytes: Optional[bytes] = None
+        best_score = -1.0
+        for png in candidate_pngs:
+            try:
+                img = self._decode(png)
+                if img is None:
+                    continue
+                faces = self._app.get(img)
+                if not faces:
+                    continue
+                score = max(float(f.det_score) for f in faces)
+                if score > best_score:
+                    best_score = score
+                    best_bytes = png
+            except Exception as e:  # noqa: BLE001
+                logger.warning("Face-swap pick_clearest failed on a candidate: %s", e)
+        return best_bytes
+
+    def swap_face_with_score(
+        self, target_png: bytes, source_png: bytes
+    ) -> tuple[Optional[bytes], float]:
+        """Swap the source identity onto the largest qualifying face in target.
+
+        Returns ``(swapped_png_bytes, source_vs_swapped_similarity)``. Returns
+        ``(None, 0.0)`` when the source has no detectable face, or the target has
+        no face passing ``settings.face_swap.min_det_score`` (e.g. heavily
+        stylised renders where detection misses) — the caller then keeps the
+        generated frame and skips gracefully.
+        """
+        if not self._load():
+            return None, 0.0
+        try:
+            import cv2  # type: ignore
+
+            from vidpipe.config import settings
+
+            src_bgr = self._decode(source_png)
+            tgt_bgr = self._decode(target_png)
+            if src_bgr is None or tgt_bgr is None:
+                return None, 0.0
+
+            src_faces = self._app.get(src_bgr)
+            if not src_faces:
+                return None, 0.0
+            src_face = max(src_faces, key=lambda f: float(f.det_score))
+
+            tgt_faces = self._app.get(tgt_bgr)
+            min_det = settings.face_swap.min_det_score
+            qualified = [f for f in tgt_faces if float(f.det_score) >= min_det]
+            if not qualified:
+                return None, 0.0
+            # Largest qualifying face = the shot's primary subject.
+            tgt_face = max(
+                qualified,
+                key=lambda f: (f.bbox[2] - f.bbox[0]) * (f.bbox[3] - f.bbox[1]),
+            )
+
+            result_bgr = self._swapper.get(
+                tgt_bgr, tgt_face, src_face, paste_back=True
+            )
+            ok, buf = cv2.imencode(".png", result_bgr)
+            if not ok:
+                return None, 0.0
+            swapped_png = buf.tobytes()
+
+            # Observability: the swapped face IS the real face, so similarity to
+            # the source should be high (POC moved 0.17 -> 0.87). A low value here
+            # is a red flag worth recording.
+            from vidpipe.qa.vision import embedding_similarity
+
+            sim = embedding_similarity(source_png, swapped_png)
+            return swapped_png, float(sim or 0.0)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Face-swap failed: %s", e)
+            return None, 0.0
+
+    def swap_face(self, target_png: bytes, source_png: bytes) -> Optional[bytes]:
+        """Swap source identity onto target; None when no usable face. Thin wrapper."""
+        out, _ = self.swap_face_with_score(target_png, source_png)
+        return out
+
+
+_SERVICE: Optional[FaceSwapService] = None
+
+
+def get_face_swap_service() -> FaceSwapService:
+    """Module-singleton accessor for the face-swap service."""
+    global _SERVICE
+    if _SERVICE is None:
+        _SERVICE = FaceSwapService()
+    return _SERVICE

--- a/backend/vidpipe/services/model_catalog.py
+++ b/backend/vidpipe/services/model_catalog.py
@@ -32,6 +32,9 @@ VIDEO_MODELS = {
     "veo-3.1-fast-generate-001",
     "veo-3.1-lite-generate-001",
     "wan-2.2-i2v",
+    "wan-2.2-flf2v",
+    "ltx-2.3-flf2v",
+    "seedance-2.0-flf2v",
 }
 
 LEGACY_MODEL_REPLACEMENTS = {
@@ -48,9 +51,12 @@ GLOBAL_REGION_MODELS = {
     "gemini-3-pro-image-preview",
 }
 
+# NOTE: computed by subtraction — new VIDEO_MODELS entries are audio-capable
+# unless explicitly excluded here.
 AUDIO_CAPABLE_VIDEO_MODELS = VIDEO_MODELS - {
     "veo-2.0-generate-001",
     "wan-2.2-i2v",
+    "wan-2.2-flf2v",
 }
 
 VIDEO_MODEL_DURATIONS: dict[str, list[int]] = {
@@ -61,6 +67,9 @@ VIDEO_MODEL_DURATIONS: dict[str, list[int]] = {
     "veo-3.1-fast-generate-001": [4, 6, 8],
     "veo-3.1-lite-generate-001": [4, 6, 8],
     "wan-2.2-i2v": [5],
+    "wan-2.2-flf2v": [5],
+    "ltx-2.3-flf2v": [4, 6, 8, 10],
+    "seedance-2.0-flf2v": list(range(4, 16)),
 }
 
 TEXT_MODEL_COST: dict[str, float] = {
@@ -85,6 +94,9 @@ IMAGE_MODEL_COST: dict[str, float] = {
     "flux-2-klein": 0.0,
 }
 
+# Seedance 2.0 is a paid ByteDance partner node, token-metered:
+# tokens/s = width*height*24/1024 → 21,600 tokens/s @720p, billed
+# ~$0.01001/1K tokens ≈ $0.216/s (audio included in token price).
 VIDEO_MODEL_COST_SILENT: dict[str, float] = {
     "veo-2.0-generate-001": 0.35,
     "veo-3.0-generate-001": 0.40,
@@ -93,6 +105,9 @@ VIDEO_MODEL_COST_SILENT: dict[str, float] = {
     "veo-3.1-fast-generate-001": 0.10,
     "veo-3.1-lite-generate-001": 0.10,
     "wan-2.2-i2v": 0.0,
+    "wan-2.2-flf2v": 0.0,
+    "ltx-2.3-flf2v": 0.0,
+    "seedance-2.0-flf2v": 0.22,
 }
 
 VIDEO_MODEL_COST_AUDIO: dict[str, float] = {
@@ -103,6 +118,9 @@ VIDEO_MODEL_COST_AUDIO: dict[str, float] = {
     "veo-3.1-fast-generate-001": 0.15,
     "veo-3.1-lite-generate-001": 0.15,
     "wan-2.2-i2v": 0.0,
+    "wan-2.2-flf2v": 0.0,
+    "ltx-2.3-flf2v": 0.0,
+    "seedance-2.0-flf2v": 0.22,
 }
 
 

--- a/backend/vidpipe/services/model_catalog.py
+++ b/backend/vidpipe/services/model_catalog.py
@@ -16,10 +16,12 @@ IMAGE_MODELS = {
     "gemini-3-pro-image-preview",
     "qwen-fast",
     "qwen-image-edit",
+    "qwen-image-edit-2509",
     "flux-dev",
     "flux-dev-lora",
     "flux-dev-redux",
     "flux-dev-full",
+    "flux-2-klein",
 }
 
 VIDEO_MODELS = {
@@ -75,10 +77,12 @@ IMAGE_MODEL_COST: dict[str, float] = {
     "gemini-3-pro-image-preview": 0.13,
     "qwen-fast": 0.0,
     "qwen-image-edit": 0.0,
+    "qwen-image-edit-2509": 0.0,
     "flux-dev": 0.0,
     "flux-dev-lora": 0.0,
     "flux-dev-redux": 0.0,
     "flux-dev-full": 0.0,
+    "flux-2-klein": 0.0,
 }
 
 VIDEO_MODEL_COST_SILENT: dict[str, float] = {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,6 +13,8 @@ services:
       - ./backend:/app/backend
       - ./config.yaml:/app/config.yaml
       - ./.env:/app/.env:ro
+      # Persist InsightFace models (inswapper_128.onnx for face-swap + buffalo_l).
+      - ./models/insightface:/root/.insightface/models
       - ${GOOGLE_APPLICATION_CREDENTIALS:-./.gcp-credentials.json}:/app/credentials.json:ro
     ports:
       - "${VIDPIPE_PORT:-8000}:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
-    gpus: all
+    gpus: all  # RTX 4070 Ti via nvidia runtime — GPU face restoration + 4x upscale (torch)
     env_file: .env
     environment:
       - VIDPIPE_STORAGE__DATABASE_URL=${VIDPIPE_STORAGE__DATABASE_URL}
@@ -16,6 +16,11 @@ services:
       - NVIDIA_DRIVER_CAPABILITIES=compute,utility
     volumes:
       - ./tmp:/app/tmp
+      # Persist InsightFace models (inswapper_128.onnx for face-swap + buffalo_l)
+      # across rebuilds. Drop inswapper_128.onnx into ./models/insightface/.
+      - ./models/insightface:/root/.insightface/models
+      # CodeFormer + RealESRGAN weights for GPU face restoration / upscaling.
+      - ./models/restore:/models/restore:ro
       - ${GOOGLE_APPLICATION_CREDENTIALS:-./.gcp-credentials.json}:/app/credentials.json:ro
     ports:
       - "${VIDPIPE_PORT:-8100}:8000"

--- a/docs/face-swap-plan.md
+++ b/docs/face-swap-plan.md
@@ -1,0 +1,46 @@
+# Face-Swap Plan — Model-Agnostic Exact-Face Locking
+
+**Status:** POC validated 2026-06-13 — pipeline integration is the remaining work.
+**Decided:** 2026-06-13 — use **face-swap** as the primary identity-locking method (chosen over LoRA for speed/flexibility; LoRA plan in `docs/lora-plan.md` remains the heavier alternative).
+
+> **POC RESULT (validated):** `inswapper_128.onnx` + buffalo_l (CPU, onnxruntime 1.26 in the backend container) swapping Brandon's real primary ref onto an in-scene keyframe moved face-embedding similarity **0.17 → 0.87** and is visually the exact real Brandon. CPU is fast enough for a 128px swap. **Start this plan at §3 (integration); §6 step 1 is done.**
+
+## 1. Goal & why this wins
+Reference-based identity (synth refs, Nano Banana, wardrobe looks) tops out ~0.75–0.85 vision identity and never *replicates* a specific face — it approximates. A **post-generation face swap** pastes the character's **real** face onto each generated keyframe, giving near-exact identity.
+
+Key consequence: **identity is decoupled from the image model.** Keyframes can be generated with any model (Qwen `qwen-image-edit-2509`, Flux `flux-2-klein`/`flux-dev`, etc.) chosen purely for composition/cost/quality — **Nano Banana is no longer required for face fidelity.** The face-swap step restores the exact face regardless of generator. Default keyframe model for testing → switch back to **Qwen / Flux** (cheaper, open).
+
+Runs on the **local GPU** (RTX 4070 Ti, CUDA verified; InsightFace already used here for QA detection).
+
+## 2. Approach
+- **Library:** InsightFace `FaceAnalysis` (already installed, `buffalo_l`) + the **inswapper** model (`inswapper_128.onnx`) for the swap. onnxruntime-gpu on the 4070 Ti (CUDAExecutionProvider).
+- **Source face:** the character's clearest real reference (e.g. Brandon's primary `2fa30ea8`); cache the source embedding/face per character.
+- **Target:** each generated keyframe. Detect the largest face → swap source identity onto it → (optional) face-restore for quality.
+- **Model acquisition:** `inswapper_128.onnx` is gated/licensed — source it deliberately (note license). Optional quality boost: GFPGAN/CodeFormer face-restoration after swap. Consider `facefusion` as a turnkey alternative if inswapper sourcing is a problem.
+
+## 3. Pipeline integration
+- New service `backend/vidpipe/services/face_swap_service.py`:
+  - `swap_face(target_png: bytes, source_png: bytes) -> bytes | None` — returns swapped image, or `None` if no face detected in target (stylized renders sometimes have undetectable faces — then skip gracefully).
+  - Lazy-load swapper + detector (singleton, CPU/GPU provider).
+- Hook in `backend/vidpipe/pipeline/keyframes.py`: **after** a keyframe is generated/verified and **before** clip generation, if the shot has on-screen character(s) with a real reference and the feature flag is on, run the swap and persist the swapped keyframe. For multi-character shots, swap each detected face to its nearest character source (start single-character).
+- Config: `settings.face_swap_enabled` (+ per-scene override), `face_swap_restore` (GFPGAN on/off), `face_swap_min_det_score`.
+- Source-face selection: reuse the QA face-clarity ranking to pick the best real ref as the swap source.
+
+## 4. Risks / mitigations
+- **Stylized targets:** inswapper is trained on real faces; on heavily stylized cyberpunk renders the swap can look pasted or the detector can miss the face. Mitigate with face-restoration blending and a det-score threshold; **POC on one keyframe first** before integrating.
+- **Pose/angle:** swaps best on near-frontal faces; extreme angles degrade — acceptable since establishing shots are usually frontal.
+- **Temporal consistency:** we swap the *keyframes*, and the FLF2V video models interpolate from them, so the swapped identity carries into the clip. If the clip still drifts mid-shot, a later enhancement is per-frame swap on the rendered clip (heavier).
+- **Licensing:** confirm inswapper usage terms for the project's context.
+
+## 5. Verification
+- QA harness (`vidpipe.qa`): `identity_match` should jump to ~0.9+ and **embeddings should rise materially** (the swapped face IS the real face — unlike stylized generations where embeddings stay low). This is the acceptance metric.
+
+## 6. Sequence (next session)
+1. ~~**POC:** acquire `inswapper_128.onnx`; swap Brandon's real face onto a keyframe; QA-score.~~ ✅ **DONE — 0.17→0.87, validated.** Model fetched from `huggingface.co/datasets/Gourieff/ReActor/resolve/main/models/inswapper_128.onnx` (554MB) to `/root/.insightface/models/inswapper_128.onnx` in the backend container. **This is ephemeral (lost on rebuild) — first integration task: bake it into the backend image or mount a volume.**
+2. Build `face_swap_service.py` + the keyframe post-hook + config flag.
+3. Switch keyframe `image_model` to **Qwen or Flux** for a test production; enable face-swap; regenerate; QA-compare faces vs the Nano Banana baseline.
+4. Tune (restoration, det threshold); roll into the standard pipeline.
+
+## 7. Relationship to other plans
+- Replaces the need for Nano Banana-for-faces and (for now) the LoRA (`docs/lora-plan.md`) — keep LoRA as a fallback for cases where face-swap underperforms (e.g. non-frontal heroes).
+- Complements the wardrobe-look pipeline (`/actor-wardrobe-presets/{id}/generate-image`), which is built but was never exercised for Brandon (presets have 0 images, 0 looks bound) — wardrobe refs still help composition/wardrobe even though face is now handled by the swap.

--- a/docs/lora-plan.md
+++ b/docs/lora-plan.md
@@ -1,0 +1,107 @@
+# Character LoRA Plan — Identity Locking for Open Models
+
+**Status:** proposal / not yet implemented
+**Author:** generated 2026-06-13
+**Goal:** Lock a character's *exact face* (e.g. `@BRANDON`) across generated keyframes by training a per-model identity **LoRA**, training it on the **local GPU**, and installing the resulting weights **manually into Comfy Cloud**.
+
+---
+
+## 1. Why this is needed
+
+Reference images alone do not lock identity well enough on the open (ComfyUI) image models. Observed behavior:
+
+- The real Brandon photos are **off-domain** (home-studio, casual) for cyberpunk-noir scenes — the model borrows wardrobe but drifts on the face.
+- We added **on-domain synthetic cyberpunk refs** (base portrait scored 0.54 face-embedding similarity) and raised reference quality, which helps, but **flux-2-klein's reference adherence is weak**: in-scene faces still land at ~0.75 vision identity (embeddings 0.04–0.31 on stylized frames).
+- The Gemini path (Nano Banana / `gemini-2.5-flash-image`) gives better identity (~0.85) but **cannot use a custom LoRA** — it is a closed API model. LoRAs only help the **open** models.
+
+A character LoRA bakes the identity into the model weights → the strongest, most consistent face lock available for the open models.
+
+> Identity LoRAs apply to the **image / keyframe** models. The video models (LTX, WAN, Seedance) are first-last-frame interpolators driven by the keyframes, so locking the keyframe identity is what matters; per-video-model character LoRAs are out of scope.
+
+---
+
+## 2. One LoRA per open model (architecture-specific)
+
+LoRA weights are tied to a specific base-model architecture — a FLUX LoRA will not load on Qwen, and a FLUX.1 LoRA will not load on FLUX.2. So **each open image model we use needs its own LoRA per character.**
+
+Open image models in use (`COMFYUI_IMAGE_MODELS` / `COMFYUI_MULTIREF_IMAGE_MODELS` in `backend/vidpipe/pipeline/keyframes.py`):
+
+| Model id | Base architecture | LoRA needed? | Notes |
+|---|---|---|---|
+| `flux-dev-lora` | FLUX.1-dev | **Yes** (primary) | Already has a LoRA workflow template (`flux-txt2img-with-lora.json`). The natural first target. |
+| `flux-2-klein` | FLUX.2 Klein | **Yes** | Confirm Klein LoRA training is supported by the training toolkit before committing. |
+| `qwen-image-edit-2509` | Qwen-Image | **Yes** | Separate Qwen-Image LoRA; different trainer config. |
+
+Closed models that **cannot** use a LoRA (skip): `gemini-2.5-flash-image` (Nano Banana), `gemini-3-pro-image-preview` (Nano Banana Pro), Veo.
+
+**Matrix:** `LoRA = {character} × {open image model}`. For Brandon across all three open models = 3 LoRA files. Start with **FLUX.1-dev** (existing workflow support) and expand.
+
+---
+
+## 3. Training on the local GPU
+
+**Hardware:** NVIDIA RTX 4070 Ti, **12 GB VRAM** (verified: WSL2 `/dev/dxg`, host `torch 2.10+cu128`, CUDA available, Docker `nvidia` runtime).
+
+**Toolkit:** [ai-toolkit](https://github.com/ostris/ai-toolkit) (Ostris) — supports FLUX.1 and FLUX.2 LoRA training with low-VRAM modes; kohya `sd-scripts` is the alternative. Neither is installed yet.
+
+**12 GB VRAM is the binding constraint.** FLUX LoRA training normally wants 16–24 GB. On 12 GB it is only feasible with aggressive settings:
+- fp8 / quantized base weights
+- 512 px training resolution
+- batch size 1 + gradient accumulation
+- gradient checkpointing, low-rank (rank 16–32)
+- expect **multi-hour** runs and OOM risk — tune down if it OOMs.
+
+**Dataset (per character):** the actor's reference images. Brandon currently has **9** (4 real + 5 on-domain synthetic cyberpunk; ≥ the 5-image minimum the app enforces). Prefer 15–30 varied, clear-face images for best results; the synthetic cyberpunk variants are valuable because they are on-domain. Auto-caption each image starting with a unique **trigger word** (the app already uses `ACTOR_{NAME}`, e.g. `ACTOR_BRANDON`) — see `lora_trainer.py::prepare_dataset`.
+
+**Per-model configs:** maintain one training config per architecture (FLUX.1-dev, FLUX.2 Klein, Qwen-Image) — base checkpoint, rank, resolution, steps differ. Keep them under e.g. `scripts/lora/configs/`.
+
+---
+
+## 4. Manual install into Comfy Cloud
+
+We use **Comfy Cloud** (`COMFY_UI_HOST=https://cloud.comfy.org`), not a self-hosted ComfyUI, so trained LoRAs must be placed on Comfy Cloud's model storage **manually** before a workflow can reference them:
+
+1. Train locally → produce `{character}_{model}.safetensors` (e.g. `brandon_flux1dev.safetensors`).
+2. Upload the `.safetensors` into the Comfy Cloud account's **LoRA model directory** (`models/loras/`) via the Comfy Cloud UI / model-upload mechanism. **Confirm Comfy Cloud allows custom LoRA upload** — this is the biggest open risk; if it does not, we must run **ComfyUI locally** on the 4070 Ti and point `COMFY_UI_HOST` at it instead (FLUX inference on 12 GB is tight but workable).
+3. Note the **exact server filename** — the workflow references the LoRA by filename (`workflow["14"]["inputs"]["lora_name"]`), not by URL.
+4. Record that filename in the actor/character record so the pipeline can inject it (see §5).
+
+Because this step is manual, the pipeline should treat the LoRA filename as **configuration**, not something it uploads.
+
+---
+
+## 5. Pipeline integration
+
+Today (`backend/vidpipe/`):
+- `lora_trainer.py` — **Replicate-cloud only** (`ReplicateBackend`, requires `settings.replicate_api_token`); `download_and_store_weights()` stores a single `.safetensors` at `asset-library/actors/{id}/lora/model.safetensors` and sets the actor's `lora_url`.
+- `keyframes.py:~2757` — for a CHARACTER reference with `aref.lora_url`, sets `flux_lora` → `build_flux_txt2img_workflow(lora_filename=...)` (template `flux-txt2img-with-lora.json`, node `14`, default `lora_strength=0.8`).
+
+Changes needed:
+1. **Per-model LoRA storage on the actor.** Replace the single `lora_url` with a map `lora_by_model: {model_id: {comfy_filename, strength, trigger_word, trained_at}}`. Migration: keep `lora_url` working as the FLUX.1-dev entry.
+2. **Local-GPU training backend.** Add a `LocalLoRATrainingBackend` to `lora_trainer.py` (runs ai-toolkit on the host GPU) so training does not require Replicate. Selectable via settings (`lora_training_backend = local | replicate`).
+3. **Manual-install registration endpoint.** Since Comfy Cloud install is manual, add an endpoint to register a trained LoRA against `(actor, model)` with its Comfy Cloud filename + trigger word, without re-uploading.
+4. **Keyframe routing per model.** When generating with an open model that has a registered LoRA for the character, inject the right filename + prepend the trigger word to the prompt. Extend beyond `flux-dev-lora` to `flux-2-klein` and `qwen-image-edit-2509` (each needs a LoRA-enabled workflow template — currently only flux has one).
+
+---
+
+## 6. Verification
+
+Use the existing QA harness (`vidpipe.qa`) to measure the win:
+- Generate establishing keyframes with and without the LoRA for the same character/scene.
+- Compare **vision identity_match** (the reliable gate; embeddings are unreliable on stylized frames) and eyeball.
+- Acceptance: establishing keyframe `identity_match ≥ 0.85` and visually unmistakable, beating the refs-only baseline (~0.70–0.75 on flux).
+
+---
+
+## 7. Recommended sequence
+
+1. **FLUX.1-dev first** (existing workflow support): install ai-toolkit → train `brandon_flux1dev.safetensors` from the 9 refs (low-VRAM config) → manually install into Comfy Cloud → register filename → switch a test scene to `flux-dev-lora` → QA-compare vs Nano Banana.
+2. If Comfy Cloud rejects custom LoRA upload → stand up **local ComfyUI** on the 4070 Ti and repoint `COMFY_UI_HOST`.
+3. Once FLUX.1-dev is proven, repeat for **FLUX.2 Klein** and **Qwen-Image** (confirm toolkit support per architecture).
+4. Generalize storage/routing to the per-model `lora_by_model` map.
+
+## 8. Open risks
+- **Comfy Cloud custom-LoRA upload** may not be supported → fallback to local ComfyUI.
+- **12 GB VRAM** for FLUX training is tight → may need fp8/512px or fall back to cloud training for FLUX, local for lighter architectures.
+- **FLUX.2 Klein LoRA** training support in ai-toolkit/kohya — verify before committing.
+- LoRA strength tuning (`lora_strength`) trades identity lock vs prompt flexibility — expose per-generation.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,7 +36,6 @@ function App() {
           <Route path="/">
             <SceneList
               onSelectScene={(id) => navigate(`/scenes/${id}`)}
-              onNewScene={() => navigate("/generate")}
               onNewDraft={handleNewDraft}
             />
           </Route>

--- a/frontend/src/components/SceneList.tsx
+++ b/frontend/src/components/SceneList.tsx
@@ -35,11 +35,10 @@ function formatCost(item: SceneListItem): string | null {
 
 interface SceneListProps {
   onSelectScene: (sceneId: string) => void;
-  onNewScene: () => void;
   onNewDraft?: () => void;
 }
 
-export function SceneList({ onSelectScene, onNewScene, onNewDraft }: SceneListProps) {
+export function SceneList({ onSelectScene, onNewDraft }: SceneListProps) {
   const { showCost } = useShowCost();
   const [viewMode, setViewMode] = useState<ViewMode>(getInitialViewMode);
   const [scenes, setScenes] = useState<SceneListItem[]>([]);
@@ -146,12 +145,6 @@ export function SceneList({ onSelectScene, onNewScene, onNewDraft }: SceneListPr
       <div className="text-center py-12">
         <p className="text-gray-500">No scenes yet.</p>
         <div className="mt-4 flex items-center justify-center gap-3">
-          <button
-            onClick={onNewScene}
-            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-500 transition-colors"
-          >
-            + New Scene
-          </button>
           {onNewDraft && (
             <button
               onClick={onNewDraft}
@@ -172,12 +165,6 @@ export function SceneList({ onSelectScene, onNewScene, onNewDraft }: SceneListPr
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <h1 className="text-2xl font-bold text-white">Scenes</h1>
-            <button
-              onClick={onNewScene}
-              className="rounded-md bg-blue-600 px-3 py-1 text-sm font-medium text-white hover:bg-blue-500 transition-colors"
-            >
-              + New
-            </button>
             {onNewDraft && (
               <button
                 onClick={onNewDraft}

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -47,6 +47,8 @@ export const TOTAL_DURATION_STEP = 5;
 // Model catalog types
 // ---------------------------------------------------------------------------
 
+export type ModelProvider = "vertex" | "comfyui";
+
 export interface TextModelOption {
   id: string;
   label: string;
@@ -57,6 +59,7 @@ export interface ImageModelOption {
   id: string;
   label: string;
   costPerImage: number;
+  provider: ModelProvider;
 }
 
 export interface VideoModelOption {
@@ -67,6 +70,7 @@ export interface VideoModelOption {
   supportsAudio: boolean;
   /** Allowed clip durations in seconds for image-to-video */
   allowedDurations: number[];
+  provider: ModelProvider;
 }
 
 // ---------------------------------------------------------------------------
@@ -81,24 +85,29 @@ export const TEXT_MODELS: TextModelOption[] = [
 ];
 
 export const IMAGE_MODELS: ImageModelOption[] = [
-  { id: "gemini-2.5-flash-image", label: "Nano Banana", costPerImage: 0.04 },
-  { id: "gemini-3-pro-image-preview", label: "Nano Banana Pro", costPerImage: 0.13 },
-  { id: "qwen-fast", label: "Qwen Fast", costPerImage: 0.00 },
-  { id: "qwen-image-edit", label: "Qwen Image Edit", costPerImage: 0.00 },
-  { id: "flux-dev", label: "Flux.1 Dev", costPerImage: 0.00 },
-  { id: "flux-dev-lora", label: "Flux.1 Dev + LoRA", costPerImage: 0.00 },
-  { id: "flux-dev-redux", label: "Flux.1 Dev + Refs", costPerImage: 0.00 },
-  { id: "flux-dev-full", label: "Flux.1 Dev Full", costPerImage: 0.00 },
+  { id: "gemini-2.5-flash-image", label: "Nano Banana", costPerImage: 0.04, provider: "vertex" },
+  { id: "gemini-3-pro-image-preview", label: "Nano Banana Pro", costPerImage: 0.13, provider: "vertex" },
+  { id: "qwen-fast", label: "Qwen Fast", costPerImage: 0.00, provider: "comfyui" },
+  { id: "qwen-image-edit", label: "Qwen Image Edit", costPerImage: 0.00, provider: "comfyui" },
+  { id: "qwen-image-edit-2509", label: "Qwen Edit 2509 (multi-ref)", costPerImage: 0.00, provider: "comfyui" },
+  { id: "flux-dev", label: "Flux.1 Dev", costPerImage: 0.00, provider: "comfyui" },
+  { id: "flux-dev-lora", label: "Flux.1 Dev + LoRA", costPerImage: 0.00, provider: "comfyui" },
+  { id: "flux-dev-redux", label: "Flux.1 Dev + Refs", costPerImage: 0.00, provider: "comfyui" },
+  { id: "flux-dev-full", label: "Flux.1 Dev Full", costPerImage: 0.00, provider: "comfyui" },
+  { id: "flux-2-klein", label: "FLUX.2 Klein", costPerImage: 0.00, provider: "comfyui" },
 ];
 
 export const VIDEO_MODELS: VideoModelOption[] = [
-  { id: "veo-2.0-generate-001", label: "Veo 2", costPerSecond: 0.35, costPerSecondAudio: 0.35, supportsAudio: false, allowedDurations: [5, 6, 7, 8] },
-  { id: "veo-3.0-generate-001", label: "Veo 3", costPerSecond: 0.40, costPerSecondAudio: 0.40, supportsAudio: true, allowedDurations: [4, 6, 8] },
-  { id: "veo-3.0-fast-generate-001", label: "Veo 3 Fast", costPerSecond: 0.15, costPerSecondAudio: 0.15, supportsAudio: true, allowedDurations: [4, 6, 8] },
-  { id: "veo-3.1-generate-001", label: "Veo 3.1 GA", costPerSecond: 0.40, costPerSecondAudio: 0.40, supportsAudio: true, allowedDurations: [4, 6, 8] },
-  { id: "veo-3.1-fast-generate-001", label: "Veo 3.1 Fast GA", costPerSecond: 0.10, costPerSecondAudio: 0.15, supportsAudio: true, allowedDurations: [4, 6, 8] },
-  { id: "veo-3.1-lite-generate-001", label: "Veo 3.1 Lite", costPerSecond: 0.10, costPerSecondAudio: 0.15, supportsAudio: true, allowedDurations: [4, 6, 8] },
-  { id: "wan-2.2-i2v", label: "Wan 2.2", costPerSecond: 0, costPerSecondAudio: 0, supportsAudio: false, allowedDurations: [5] },
+  { id: "veo-2.0-generate-001", label: "Veo 2", costPerSecond: 0.35, costPerSecondAudio: 0.35, supportsAudio: false, allowedDurations: [5, 6, 7, 8], provider: "vertex" },
+  { id: "veo-3.0-generate-001", label: "Veo 3", costPerSecond: 0.40, costPerSecondAudio: 0.40, supportsAudio: true, allowedDurations: [4, 6, 8], provider: "vertex" },
+  { id: "veo-3.0-fast-generate-001", label: "Veo 3 Fast", costPerSecond: 0.15, costPerSecondAudio: 0.15, supportsAudio: true, allowedDurations: [4, 6, 8], provider: "vertex" },
+  { id: "veo-3.1-generate-001", label: "Veo 3.1 GA", costPerSecond: 0.40, costPerSecondAudio: 0.40, supportsAudio: true, allowedDurations: [4, 6, 8], provider: "vertex" },
+  { id: "veo-3.1-fast-generate-001", label: "Veo 3.1 Fast GA", costPerSecond: 0.10, costPerSecondAudio: 0.15, supportsAudio: true, allowedDurations: [4, 6, 8], provider: "vertex" },
+  { id: "veo-3.1-lite-generate-001", label: "Veo 3.1 Lite", costPerSecond: 0.10, costPerSecondAudio: 0.15, supportsAudio: true, allowedDurations: [4, 6, 8], provider: "vertex" },
+  { id: "wan-2.2-i2v", label: "Wan 2.2", costPerSecond: 0, costPerSecondAudio: 0, supportsAudio: false, allowedDurations: [5], provider: "comfyui" },
+  { id: "wan-2.2-flf2v", label: "Wan 2.2 FLF2V", costPerSecond: 0, costPerSecondAudio: 0, supportsAudio: false, allowedDurations: [5], provider: "comfyui" },
+  { id: "ltx-2.3-flf2v", label: "LTX 2.3 FLF2V", costPerSecond: 0, costPerSecondAudio: 0, supportsAudio: true, allowedDurations: [4, 6, 8, 10], provider: "comfyui" },
+  { id: "seedance-2.0-flf2v", label: "Seedance 2.0 (paid)", costPerSecond: 0.22, costPerSecondAudio: 0.22, supportsAudio: true, allowedDurations: [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], provider: "comfyui" },
 ];
 
 // ---------------------------------------------------------------------------
@@ -110,22 +119,22 @@ export const VERTEX_TEXT_MODELS = TEXT_MODELS;
 
 /** Vertex Studio image models (Gemini-based) */
 export const VERTEX_IMAGE_MODELS = IMAGE_MODELS.filter(
-  (m) => m.id.startsWith("gemini-"),
+  (m) => m.provider === "vertex",
 );
 
 /** Vertex Studio video models (Veo family) */
 export const VERTEX_VIDEO_MODELS = VIDEO_MODELS.filter(
-  (m) => m.id.startsWith("veo-"),
+  (m) => m.provider === "vertex",
 );
 
-/** ComfyUI video models (Wan family) */
+/** ComfyUI video models (Wan, LTX, Seedance) */
 export const COMFYUI_VIDEO_MODELS_LIST = VIDEO_MODELS.filter(
-  (m) => m.id.startsWith("wan-"),
+  (m) => m.provider === "comfyui",
 );
 
 /** ComfyUI image models */
 export const COMFYUI_IMAGE_MODELS = IMAGE_MODELS.filter(
-  (m) => !m.id.startsWith("gemini-"),
+  (m) => m.provider === "comfyui",
 );
 
 /** Image models that support reference images */
@@ -133,8 +142,10 @@ export const REFERENCE_IMAGE_MODELS = new Set([
   "gemini-2.5-flash-image",
   "gemini-3-pro-image-preview",
   "qwen-image-edit",
+  "qwen-image-edit-2509",
   "flux-dev-redux",
   "flux-dev-full",
+  "flux-2-klein",
 ]);
 
 // ---------------------------------------------------------------------------

--- a/scripts/start-stack.sh
+++ b/scripts/start-stack.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# start-stack.sh — bring the full vidpipe stack up safely (Supabase + app).
+#
+# Why this exists: on Docker Desktop + WSL2 the bind-mount cache under
+# /run/desktop/mnt/host/wsl/docker-desktop-bind-mounts/ goes stale after a
+# Docker Desktop or WSL restart. That causes two failure modes this script
+# detects and repairs automatically:
+#
+#   1. Containers Exit(127) with "OCI runtime create failed ... not a directory:
+#      Are you trying to mount a directory onto a file?" — a stale single-file
+#      bind mount. A plain `docker restart` reuses the broken spec and loops;
+#      the fix is to RECREATE (down + up) so Docker re-resolves the mount.
+#
+#   2. MinIO sees an EMPTY view of its shared ./volumes/storage drive, logs
+#      "Formatting 1st pool", and serves a blank bucket (media 400/500) — even
+#      though the real objects are still on disk (visible to supabase-storage,
+#      which mounts the same host dir). The fix is to force-recreate just MinIO
+#      so its /data mount re-resolves to the canonical host path.
+#
+# Supabase must always run with BOTH compose files. The base docker-compose.yml
+# sets storage to STORAGE_BACKEND=file (which chokes on MinIO's directory-format
+# objects → EISDIR/500) and does not define minio; docker-compose.s3.yml switches
+# storage to s3 → http://minio:9000 and defines the minio service.
+#
+# Usage:
+#   scripts/start-stack.sh            # bring everything up safely
+#   scripts/start-stack.sh --build    # also rebuild the app images
+#   SUPABASE_DIR=/path scripts/start-stack.sh
+#
+# Safe to run repeatedly — it is idempotent and never passes `down -v`, so
+# database (./volumes/db/data) and object storage (./volumes/storage) are never
+# wiped.
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+info()  { echo -e "${CYAN}[INFO]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error() { echo -e "${RED}[ERROR]${NC} $*"; }
+ok()    { echo -e "${GREEN}[OK]${NC} $*"; }
+
+APP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SUPABASE_DIR="${SUPABASE_DIR:-$(cd "$APP_DIR/.." && pwd)/supabase-project}"
+SUPABASE_FILES=(-f docker-compose.yml -f docker-compose.s3.yml)
+BACKEND_PORT="${VIDPIPE_PORT:-8100}"
+FRONTEND_PORT="${VIDPIPE_FRONTEND_PORT:-80}"
+BUILD=""
+[[ "${1:-}" == "--build" ]] && BUILD="--build"
+
+# Load app .env so VIDPIPE_PORT / VIDPIPE_FRONTEND_PORT overrides apply.
+if [[ -f "$APP_DIR/.env" ]]; then
+    BACKEND_PORT="$(grep -oP '(?<=^VIDPIPE_PORT=).*' "$APP_DIR/.env" 2>/dev/null || echo "$BACKEND_PORT")"
+    FRONTEND_PORT="$(grep -oP '(?<=^VIDPIPE_FRONTEND_PORT=).*' "$APP_DIR/.env" 2>/dev/null || echo "$FRONTEND_PORT")"
+fi
+
+sb() { (cd "$SUPABASE_DIR" && docker compose "${SUPABASE_FILES[@]}" "$@"); }
+
+preflight() {
+    command -v docker &>/dev/null || { error "Docker is not installed or not in PATH."; exit 1; }
+    docker compose version &>/dev/null || { error "Docker Compose v2 plugin is not available."; exit 1; }
+    [[ -d "$SUPABASE_DIR" ]] || { error "Supabase dir not found: $SUPABASE_DIR (set SUPABASE_DIR=...)."; exit 1; }
+    [[ -f "$SUPABASE_DIR/docker-compose.yml" && -f "$SUPABASE_DIR/docker-compose.s3.yml" ]] || {
+        error "Expected docker-compose.yml + docker-compose.s3.yml in $SUPABASE_DIR."; exit 1; }
+    [[ -f "$APP_DIR/.env" ]] || warn ".env not found in $APP_DIR — backend may not start. Copy .env.example."
+    ok "Pre-flight checks passed. Supabase: $SUPABASE_DIR"
+}
+
+# Repair failure mode #1: stale single-file bind mounts → Exit(127) "not a directory".
+repair_stale_mounts() {
+    local broken=""
+    local id state
+    while read -r id; do
+        [[ -z "$id" ]] && continue
+        state="$(docker inspect "$id" --format '{{.State.ExitCode}} {{.State.Error}}' 2>/dev/null || true)"
+        if grep -qiE '^127 |not a directory|OCI runtime create' <<<"$state"; then
+            broken+="$id "
+        fi
+    done < <(sb ps -aq 2>/dev/null || true)
+    if [[ -n "$broken" ]]; then
+        warn "Detected stale bind-mount failure (Exit 127). Recreating the Supabase stack..."
+        sb down                       # never -v — bind-mounted data is preserved
+        sb up -d
+        ok "Supabase stack recreated."
+    fi
+}
+
+# Repair failure mode #2: MinIO mounted a stale/empty view and formatted an empty pool.
+repair_minio_divergence() {
+    local minio_id storage_id minio_mb storage_mb
+    minio_id="$(sb ps -q minio 2>/dev/null || true)"
+    storage_id="$(sb ps -q storage 2>/dev/null || true)"
+    [[ -z "$minio_id" || -z "$storage_id" ]] && return 0
+
+    minio_mb="$(docker exec "$minio_id" du -sm /data 2>/dev/null | awk '{print $1}')"
+    storage_mb="$(docker exec "$storage_id" du -sm /var/lib/storage 2>/dev/null | awk '{print $1}')"
+    [[ -z "$minio_mb" || -z "$storage_mb" ]] && return 0
+
+    # Both containers bind-mount the SAME host dir. In a healthy state the sizes
+    # match. If supabase-storage sees materially more data than MinIO, MinIO's
+    # mount is stale (it formatted an empty pool) while the real objects survive.
+    if (( storage_mb > minio_mb + 5 )); then
+        warn "MinIO sees ${minio_mb}MB but the real volume holds ${storage_mb}MB — stale mount / formatted pool."
+        warn "Force-recreating MinIO so its /data mount re-resolves to the real objects..."
+        sb up -d --force-recreate --no-deps minio
+        sleep 8
+        minio_mb="$(docker exec "$minio_id" du -sm /data 2>/dev/null | awk '{print $1}')" || true
+        # Re-resolve id (force-recreate replaces the container).
+        minio_id="$(sb ps -q minio 2>/dev/null || true)"
+        minio_mb="$(docker exec "$minio_id" du -sm /data 2>/dev/null | awk '{print $1}')"
+        if (( storage_mb > minio_mb + 5 )); then
+            error "MinIO still does not see the data (${minio_mb}MB vs ${storage_mb}MB)."
+            error "The Docker Desktop WSL bind-mount cache may need a full restart of Docker Desktop."
+            error "Real objects are intact on the host at $SUPABASE_DIR/volumes/storage — they were NOT lost."
+            return 1
+        fi
+        ok "MinIO re-attached to the real volume (${minio_mb}MB)."
+    fi
+}
+
+verify_storage_backend() {
+    local backend
+    backend="$(docker exec "$(sb ps -q storage)" printenv STORAGE_BACKEND 2>/dev/null || true)"
+    if [[ "$backend" != "s3" ]]; then
+        error "supabase-storage is STORAGE_BACKEND=$backend (expected s3). The S3 overlay did not apply."
+        exit 1
+    fi
+    ok "Storage backend is s3 → MinIO."
+}
+
+wait_healthy() {  # wait_healthy <container-id> <label> <timeout-s>
+    local id="$1" label="$2" timeout="${3:-90}" waited=0 status
+    [[ -z "$id" ]] && { warn "$label: container not found, skipping health wait."; return 0; }
+    while (( waited < timeout )); do
+        status="$(docker inspect "$id" --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' 2>/dev/null || echo unknown)"
+        [[ "$status" == "healthy" || "$status" == "running" ]] && { ok "$label is $status."; return 0; }
+        sleep 3; waited=$((waited+3))
+    done
+    warn "$label did not become healthy within ${timeout}s (status: ${status:-unknown})."
+}
+
+main() {
+    preflight
+
+    info "Starting Supabase (with S3 overlay)..."
+    sb up -d
+    repair_stale_mounts
+    wait_healthy "$(sb ps -q db)" "supabase-db" 120
+    repair_minio_divergence
+    verify_storage_backend
+
+    info "Starting vidpipe app..."
+    (cd "$APP_DIR" && docker compose up -d $BUILD)
+
+    info "Waiting for backend to come up..."
+    local waited=0
+    until curl -fsS -o /dev/null "http://localhost:${BACKEND_PORT}/api/health" 2>/dev/null; do
+        sleep 3; waited=$((waited+3))
+        if (( waited >= 90 )); then
+            error "Backend health check failed after 90s. Recent logs:"
+            (cd "$APP_DIR" && docker compose logs --tail 30 backend) || true
+            exit 1
+        fi
+    done
+    ok "Backend healthy: http://localhost:${BACKEND_PORT}/api/health"
+
+    if curl -fsS -o /dev/null "http://localhost:${FRONTEND_PORT}/" 2>/dev/null; then
+        ok "Frontend reachable: http://localhost:${FRONTEND_PORT}/"
+    else
+        warn "Frontend not reachable on port ${FRONTEND_PORT} yet."
+    fi
+
+    echo ""
+    ok "Stack is up."
+    info "Frontend: http://localhost:${FRONTEND_PORT}/"
+    info "Backend:  http://localhost:${BACKEND_PORT}/  (API under /api)"
+    info "Note: supabase-storage may report (unhealthy) — its healthcheck probes IPv6 localhost"
+    info "      while it serves on IPv4. It is cosmetic; real traffic via storage:5000 works."
+}
+
+main "$@"

--- a/settings-loaded.yml
+++ b/settings-loaded.yml
@@ -1,0 +1,334 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - generic [ref=e5]:
+      - link "vidpipe" [ref=e6] [cursor=pointer]:
+        - /url: /
+      - navigation [ref=e7]:
+        - link "Dashboard" [ref=e8] [cursor=pointer]:
+          - /url: /dashboard
+        - link "Productions" [ref=e9] [cursor=pointer]:
+          - /url: /productions
+        - link "Scenes" [ref=e10] [cursor=pointer]:
+          - /url: /
+        - link "Production Bibles" [ref=e11] [cursor=pointer]:
+          - /url: /production-bibles
+        - link "Asset Library" [ref=e12] [cursor=pointer]:
+          - /url: /asset-library
+        - link "Settings" [ref=e13] [cursor=pointer]:
+          - /url: /settings
+  - main [ref=e14]:
+    - generic [ref=e15]:
+      - generic [ref=e16]:
+        - heading "Settings" [level=1] [ref=e17]
+        - paragraph [ref=e18]: Configure enabled models, defaults, and API credentials.
+      - generic [ref=e19]:
+        - heading "Display" [level=2] [ref=e20]
+        - generic [ref=e21]:
+          - generic [ref=e22]:
+            - text: Show Cost Estimates
+            - paragraph [ref=e23]: Display estimated costs on scenes, forms, and dashboard
+          - button [ref=e24]
+      - generic [ref=e26]:
+        - button "Default Models" [ref=e27]:
+          - heading "Default Models" [level=2] [ref=e28]
+          - img [ref=e29]
+        - generic [ref=e31]:
+          - paragraph [ref=e32]: Pre-selected models when creating a new scene. All optional.
+          - generic [ref=e33]:
+            - generic [ref=e34]: Text Model
+            - generic [ref=e35]:
+              - button "None" [ref=e36]
+              - button "Gemini 2.5 Pro" [ref=e37]
+              - button "Gemini 3 Flash" [ref=e38]
+              - button "Gemini 3.1 Pro" [ref=e39]
+              - button "Gemini 3.5 Flash" [ref=e40]
+              - button "qwen3.5:397b-cloud (Ollama)" [ref=e41]
+              - button "kimi-k2.5:cloud (Ollama)" [ref=e42]
+              - button "minimax-m2.7:cloud (Ollama)" [ref=e43]
+          - generic [ref=e44]:
+            - generic [ref=e45]: Image Model
+            - generic [ref=e46]:
+              - button "None" [ref=e47]
+              - button "Nano Banana" [ref=e48]
+              - button "Nano Banana Pro" [ref=e49]
+              - button "Qwen Image Edit" [ref=e50]
+              - button "Qwen Edit 2509 (multi-ref)" [ref=e51]
+              - button "FLUX.2 Klein" [ref=e52]
+          - generic [ref=e53]:
+            - generic [ref=e54]: Video Model
+            - generic [ref=e55]:
+              - button "None" [ref=e56]
+              - button "Veo 3.1 GA" [ref=e57]
+              - button "Veo 3.1 Fast GA" [ref=e58]
+              - button "Veo 3.1 Lite" [ref=e59]
+              - button "Wan 2.2" [ref=e60]
+              - button "Wan 2.2 FLF2V" [ref=e61]
+              - button "LTX 2.3 FLF2V" [ref=e62]
+              - button "Seedance 2.0 (paid)" [ref=e63]
+          - generic [ref=e64]:
+            - generic [ref=e65]: Vision ModelFor image analysis and reverse-prompting
+            - generic [ref=e66]:
+              - button "None" [ref=e67]
+              - button "Gemini 2.5 Pro" [ref=e68]
+              - button "Gemini 3 Flash" [ref=e69]
+              - button "Gemini 3.1 Pro" [ref=e70]
+              - button "Gemini 3.5 Flash" [ref=e71]
+              - button "qwen3.5:397b-cloud (Ollama)" [ref=e72]
+              - button "kimi-k2.5:cloud (Ollama)" [ref=e73]
+              - button "minimax-m2.7:cloud (Ollama)" [ref=e74]
+          - generic [ref=e75]:
+            - generic [ref=e76]: Voice IDElevenLabs
+            - textbox "e.g. EXAVITQu4vr4xnSDxMaL" [ref=e77]: mvsi7032MOMSPunnESTu
+            - paragraph [ref=e78]: Pre-filled when creating new voice profiles on characters and actors.
+      - generic [ref=e79]:
+        - button "Vertex Studio" [ref=e80]:
+          - heading "Vertex Studio" [level=2] [ref=e81]
+          - img [ref=e82]
+        - generic [ref=e84]:
+          - generic [ref=e85]:
+            - heading "API Settings" [level=3] [ref=e86]
+            - generic [ref=e87]:
+              - generic [ref=e88]:
+                - generic [ref=e89]: Project ID
+                - textbox "my-gcp-project" [ref=e90]
+              - generic [ref=e91]:
+                - generic [ref=e92]: Location
+                - textbox "us-central1" [ref=e93]
+            - generic [ref=e94]:
+              - generic [ref=e95]: API Key
+              - textbox "Enter API key" [ref=e96]
+            - generic [ref=e97]:
+              - generic [ref=e98]: Service Account JSON
+              - paragraph [ref=e99]: Upload your GCP service account key file (.json). Project ID and Location will be auto-populated if empty.
+              - generic [ref=e100]:
+                - generic [ref=e101] [cursor=pointer]: Choose file...
+                - generic [ref=e102]: Service account is set
+              - button "Clear service account" [ref=e104]
+          - generic [ref=e105]:
+            - heading "Text Models" [level=3] [ref=e106]
+            - generic [ref=e107]:
+              - generic [ref=e108]:
+                - generic [ref=e109]:
+                  - generic [ref=e110]: Gemini 2.5 Pro
+                  - generic [ref=e111]: gemini-2.5-pro
+                  - generic [ref=e112]: Vision
+                - button [ref=e113]
+              - generic [ref=e115]:
+                - generic [ref=e116]:
+                  - generic [ref=e117]: Gemini 3 Flash
+                  - generic [ref=e118]: gemini-3-flash-preview
+                  - generic [ref=e119]: Vision
+                - button [ref=e120]
+              - generic [ref=e122]:
+                - generic [ref=e123]:
+                  - generic [ref=e124]: Gemini 3.1 Pro
+                  - generic [ref=e125]: gemini-3.1-pro-preview
+                  - generic [ref=e126]: Vision
+                - button [ref=e127]
+              - generic [ref=e129]:
+                - generic [ref=e130]:
+                  - generic [ref=e131]: Gemini 3.5 Flash
+                  - generic [ref=e132]: gemini-3.5-flash
+                  - generic [ref=e133]: Vision
+                - button [ref=e134]
+          - generic [ref=e136]:
+            - heading "Image Models" [level=3] [ref=e137]
+            - generic [ref=e138]:
+              - generic [ref=e139]:
+                - generic [ref=e140]:
+                  - generic [ref=e141]: Nano Banana
+                  - generic [ref=e142]: gemini-2.5-flash-image
+                - button [ref=e143]
+              - generic [ref=e145]:
+                - generic [ref=e146]:
+                  - generic [ref=e147]: Nano Banana Pro
+                  - generic [ref=e148]: gemini-3-pro-image-preview
+                - button [ref=e149]
+          - generic [ref=e151]:
+            - heading "Video Models" [level=3] [ref=e152]
+            - generic [ref=e153]:
+              - generic [ref=e154]:
+                - generic [ref=e155]:
+                  - generic [ref=e156]: Veo 2
+                  - generic [ref=e157]: veo-2.0-generate-001
+                - button [ref=e158]
+              - generic [ref=e160]:
+                - generic [ref=e161]:
+                  - generic [ref=e162]: Veo 3
+                  - generic [ref=e163]: veo-3.0-generate-001
+                - button [ref=e164]
+              - generic [ref=e166]:
+                - generic [ref=e167]:
+                  - generic [ref=e168]: Veo 3 Fast
+                  - generic [ref=e169]: veo-3.0-fast-generate-001
+                - button [ref=e170]
+              - generic [ref=e172]:
+                - generic [ref=e173]:
+                  - generic [ref=e174]: Veo 3.1 GA
+                  - generic [ref=e175]: veo-3.1-generate-001
+                - button [ref=e176]
+              - generic [ref=e178]:
+                - generic [ref=e179]:
+                  - generic [ref=e180]: Veo 3.1 Fast GA
+                  - generic [ref=e181]: veo-3.1-fast-generate-001
+                - button [ref=e182]
+              - generic [ref=e184]:
+                - generic [ref=e185]:
+                  - generic [ref=e186]: Veo 3.1 Lite
+                  - generic [ref=e187]: veo-3.1-lite-generate-001
+                - button [ref=e188]
+      - generic [ref=e190]:
+        - button "ComfyUI" [ref=e191]:
+          - heading "ComfyUI" [level=2] [ref=e192]
+          - img [ref=e193]
+        - generic [ref=e195]:
+          - generic [ref=e196]:
+            - heading "API Settings" [level=3] [ref=e197]
+            - generic [ref=e198]:
+              - generic [ref=e199]: Host URL
+              - textbox "https://api.comfy.org" [ref=e200]: https://cloud.comfy.org
+            - generic [ref=e201]:
+              - generic [ref=e202]: API Key
+              - textbox "API key is set (leave blank to keep)" [ref=e203]
+              - generic [ref=e204]:
+                - generic [ref=e205]: API key is set
+                - button "Clear key" [ref=e206]
+            - generic [ref=e207]:
+              - generic [ref=e208]: Cost per Second ($)
+              - spinbutton [ref=e209]: "0.03"
+              - paragraph [ref=e210]: Leave empty for $0.00. Used for cost estimation in the Generate form.
+          - generic [ref=e211]:
+            - heading "Video Models" [level=3] [ref=e212]
+            - generic [ref=e213]:
+              - generic [ref=e214]:
+                - generic [ref=e215]:
+                  - generic [ref=e216]: Wan 2.2
+                  - generic [ref=e217]: wan-2.2-i2v
+                - button [ref=e218]
+              - generic [ref=e220]:
+                - generic [ref=e221]:
+                  - generic [ref=e222]: Wan 2.2 FLF2V
+                  - generic [ref=e223]: wan-2.2-flf2v
+                - button [ref=e224]
+              - generic [ref=e226]:
+                - generic [ref=e227]:
+                  - generic [ref=e228]: LTX 2.3 FLF2V
+                  - generic [ref=e229]: ltx-2.3-flf2v
+                - button [ref=e230]
+              - generic [ref=e232]:
+                - generic [ref=e233]:
+                  - generic [ref=e234]: Seedance 2.0 (paid)
+                  - generic [ref=e235]: seedance-2.0-flf2v
+                - button [ref=e236]
+          - generic [ref=e238]:
+            - heading "Image Models" [level=3] [ref=e239]
+            - generic [ref=e240]:
+              - generic [ref=e241]:
+                - generic [ref=e242]:
+                  - generic [ref=e243]: Qwen Fast
+                  - generic [ref=e244]: qwen-fast
+                - button [ref=e245]
+              - generic [ref=e247]:
+                - generic [ref=e248]:
+                  - generic [ref=e249]: Qwen Image Edit
+                  - generic [ref=e250]: qwen-image-edit
+                - button [ref=e251]
+              - generic [ref=e253]:
+                - generic [ref=e254]:
+                  - generic [ref=e255]: Qwen Edit 2509 (multi-ref)
+                  - generic [ref=e256]: qwen-image-edit-2509
+                - button [ref=e257]
+              - generic [ref=e259]:
+                - generic [ref=e260]:
+                  - generic [ref=e261]: Flux.1 Dev
+                  - generic [ref=e262]: flux-dev
+                - button [ref=e263]
+              - generic [ref=e265]:
+                - generic [ref=e266]:
+                  - generic [ref=e267]: Flux.1 Dev + LoRA
+                  - generic [ref=e268]: flux-dev-lora
+                - button [ref=e269]
+              - generic [ref=e271]:
+                - generic [ref=e272]:
+                  - generic [ref=e273]: Flux.1 Dev + Refs
+                  - generic [ref=e274]: flux-dev-redux
+                - button [ref=e275]
+              - generic [ref=e277]:
+                - generic [ref=e278]:
+                  - generic [ref=e279]: Flux.1 Dev Full
+                  - generic [ref=e280]: flux-dev-full
+                - button [ref=e281]
+              - generic [ref=e283]:
+                - generic [ref=e284]:
+                  - generic [ref=e285]: FLUX.2 Klein
+                  - generic [ref=e286]: flux-2-klein
+                - button [ref=e287]
+      - generic [ref=e289]:
+        - button "Ollama" [ref=e290]:
+          - heading "Ollama" [level=2] [ref=e291]
+          - img [ref=e292]
+        - generic [ref=e294]:
+          - generic [ref=e295]:
+            - heading "API Settings" [level=3] [ref=e296]
+            - generic [ref=e297]:
+              - generic [ref=e298]: "Mode:"
+              - button "Local" [ref=e299]
+              - button "Cloud" [ref=e300]
+            - generic [ref=e301]:
+              - generic [ref=e302]: API Key
+              - textbox "Key is set (leave blank to keep)" [ref=e303]
+              - text: API key is set
+            - generic [ref=e304]:
+              - generic [ref=e305]: Endpoint URL
+              - textbox "https://ollama.com" [ref=e306]
+              - paragraph [ref=e307]: "Leave empty for default. Local: http://localhost:11434, Cloud: https://ollama.com"
+          - generic [ref=e308]:
+            - heading "Models" [level=3] [ref=e309]
+            - generic [ref=e310]:
+              - textbox "e.g. llama3.2-vision" [ref=e311]
+              - button "Add" [ref=e312]
+            - generic [ref=e313]:
+              - generic [ref=e314]:
+                - generic [ref=e315]:
+                  - generic [ref=e316]: qwen3.5:397b-cloud
+                  - generic [ref=e317]: ollama/qwen3.5:397b-cloud
+                  - button "Vision" [ref=e318]
+                - generic [ref=e319]:
+                  - button [ref=e320]
+                  - button "Remove" [ref=e322]
+              - generic [ref=e323]:
+                - generic [ref=e324]:
+                  - generic [ref=e325]: kimi-k2.5:cloud
+                  - generic [ref=e326]: ollama/kimi-k2.5:cloud
+                  - button "Vision" [ref=e327]
+                - generic [ref=e328]:
+                  - button [ref=e329]
+                  - button "Remove" [ref=e331]
+              - generic [ref=e332]:
+                - generic [ref=e333]:
+                  - generic [ref=e334]: gemma3:27b-cloud
+                  - generic [ref=e335]: ollama/gemma3:27b-cloud
+                  - button "Vision" [ref=e336]
+                - generic [ref=e337]:
+                  - button [ref=e338]
+                  - button "Remove" [ref=e340]
+              - generic [ref=e341]:
+                - generic [ref=e342]:
+                  - generic [ref=e343]: gpt-oss:120b-cloud
+                  - generic [ref=e344]: ollama/gpt-oss:120b-cloud
+                  - button "Vision" [ref=e345]
+                - generic [ref=e346]:
+                  - button [ref=e347]
+                  - button "Remove" [ref=e349]
+              - generic [ref=e350]:
+                - generic [ref=e351]:
+                  - generic [ref=e352]: minimax-m2.7:cloud
+                  - generic [ref=e353]: ollama/minimax-m2.7:cloud
+                  - button "Vision" [ref=e354]
+                - generic [ref=e355]:
+                  - button [ref=e356]
+                  - button "Remove" [ref=e358]
+      - button "ElevenLabs" [ref=e360]:
+        - heading "ElevenLabs" [level=2] [ref=e361]
+        - img [ref=e362]
+      - button "Save Settings" [ref=e364]


### PR DESCRIPTION
## Summary

Adds five new ComfyUI Cloud models across both pipelines:

| Model | Capability |
|---|---|
| `qwen-image-edit-2509` | 1–3 identity reference images, Nano Banana-style (Apache 2.0) |
| `flux-2-klein` | 0–4 reference images / plain txt2img (FLUX.2 Klein 4B, Apache 2.0) |
| `wan-2.2-flf2v` | Start+end keyframe interpolation (same weights as wan-2.2-i2v) |
| `ltx-2.3-flf2v` | Start+end keyframes, 25fps, 4–10s, **native audio** (open weights) |
| `seedance-2.0-flf2v` | Start+(optional)end, 4–15s, audio — paid ByteDance partner node, $0.22/s |

## Key changes

- **Templates**: minimal API-format graphs hand-assembled from official Comfy-Org subgraph templates, node schemas verified against ComfyUI source; raw templates archived in `docs/comfyui-templates/`
- **Image path**: ComfyUI models now use the full Nano Banana reference machinery (identity policy, emphasis escalation, face verification) via the new `COMFYUI_MULTIREF_IMAGE_MODELS` gate; end-frame mode gives ComfyUI models true start-frame conditioning (image1/ref-slot-1 = start frame)
- **Video path**: per-model `COMFY_VIDEO_SPECS` registry generalizes the adapter (was WAN-only with hard-coded 81/16 duration); end keyframe finally wired in; missing end keyframe = soft degrade to first-frame-only; `duration_seconds`/`audio_enabled` plumbed through both the pipeline and `_regenerate_clip`
- **Frontend**: explicit `provider` field replaces fragile `id.startsWith` grouping; new model entries with durations/audio/cost
- ADR: `.planning/decisions/2026-06-11-comfyui-new-models.md`

## Verification

- 34 new unit tests; full backend suite 84 passed (2 failures pre-exist on master)
- **Live Comfy Cloud smoke tests**: qwen-2509 ✅ (1664×928 at requested scene dims), flux2-klein ✅, ltx ✅ (h264 25fps + non-silent AAC audio verified with ffprobe)
- Seedance: workflow validated by the node, blocked on partner-node account auth ("Please login first") — needs Comfy Org account login/credits, documented in the ADR
- Frontend: tsc clean, lint baseline unchanged

## Follow-ups

- Seedance partner-node auth setup on the Comfy account, then one paid E2E clip
- E2E scene runs per video model in dev docker (resume + regen paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)